### PR TITLE
fix: use Netlify CLI + Next.js plugin for deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,14 +14,9 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npm run build
-      - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v3
-        with:
-          publish-dir: .next
-          production-branch: main
-          production-deploy: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm install -g netlify-cli
+      - name: Deploy to Netlify (production)
+        run: netlify deploy --build --prod --message "Deploy from main (${{ github.sha }})"
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,15 +14,22 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npm run build
+      - run: npm install -g netlify-cli
       - name: Deploy Preview to Netlify
-        uses: nwtgck/actions-netlify@v3
-        with:
-          publish-dir: .next
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
-          enable-pull-request-comment: true
-          enable-commit-comment: false
+        id: netlify
+        run: |
+          OUTPUT=$(netlify deploy --build --message "PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}" --json)
+          echo "url=$(echo $OUTPUT | jq -r '.deploy_url')" >> $GITHUB_OUTPUT
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### Netlify Preview\n🔗 ${{ steps.netlify.outputs.url }}`
+            })

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "19.2.4"
       },
       "devDependencies": {
+        "@netlify/plugin-nextjs": "^5.15.9",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1037,6 +1038,16 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@netlify/plugin-nextjs": {
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.15.9.tgz",
+      "integrity": "sha512-4kJvV+wrt4/ncehfaOXfhv1FYKCv9EFjq6/tgXXYSlqPDcbsuTXR0DTz9IvyZ/CpPRadRD/zzIqD9wXgCmA2lg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "*.{js,mjs,json,css,md}": "prettier --write"
   },
   "devDependencies": {
+    "@netlify/plugin-nextjs": "^5.15.9",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",


### PR DESCRIPTION
## Summary
- Add `netlify.toml` with `@netlify/plugin-nextjs` — required for Netlify to serve a Next.js SSR app
- Replace `nwtgck/actions-netlify` (which errors with `.next` publish dir) with `netlify-cli` in both `deploy.yml` and `preview.yml`

## Why
`nwtgck/actions-netlify` with `publish-dir: .next` fails with "No files or functions to deploy" because `.next` is not a static export — Netlify needs the plugin to handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)