### PR TITLE
feat: wire homepage sections together

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,17 @@
 import { Hero } from '@/components/home/Hero'
 import { FeaturedProjects } from '@/components/home/FeaturedProjects'
 import { LatestPosts } from '@/components/home/LatestPosts'
+import { CallToAction } from '@/components/home/CallToAction'
 
 export default function Home() {
   return (
     <main>
       <Hero />
-      <FeaturedProjects />
+      <section className="bg-[var(--color-bg-subtle)]">
+        <FeaturedProjects />
+      </section>
       <LatestPosts />
+      <CallToAction />
     </main>
   )
 }

--- a/src/components/home/CallToAction.tsx
+++ b/src/components/home/CallToAction.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+
+export function CallToAction() {
+  return (
+    <section className="bg-[var(--color-bg-subtle)]">
+      <div className="mx-auto max-w-6xl px-6 py-20 text-center">
+        <h2 className="mb-4 text-3xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-4xl">
+          Let&apos;s build something together
+        </h2>
+        <p className="mx-auto mb-8 max-w-xl text-lg text-[var(--color-text-muted)]">
+          Have a project in mind or just want to say hello? My inbox is always open.
+        </p>
+        <Link
+          href="/contact"
+          className="inline-block rounded-lg bg-[var(--color-primary)] px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-primary-hover)]"
+        >
+          Get in Touch
+        </Link>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- Wrap `FeaturedProjects` in a `bg-subtle` section for alternating visual rhythm
- Add `CallToAction` component at the bottom with a "Get in Touch" CTA

Closes #41

## Test plan
- [ ] Alternating section backgrounds visible in light and dark mode
- [ ] CTA section renders correctly and links to `/contact`
- [ ] No TypeScript or lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)