### PR TITLE
feat: define Project TypeScript type

### DIFF
--- a/src/components/home/FeaturedProjects.tsx
+++ b/src/components/home/FeaturedProjects.tsx
@@ -1,13 +1,6 @@
 import Link from 'next/link'
 
-interface Project {
-  slug: string
-  title: string
-  description: string
-  tags: string[]
-  githubUrl?: string
-  liveUrl?: string
-}
+import { type Project } from '@/types/project'
 
 const FEATURED_PROJECTS: Project[] = [
   {
@@ -18,6 +11,7 @@ const FEATURED_PROJECTS: Project[] = [
     tags: ['Next.js', 'TypeScript', 'PostgreSQL'],
     githubUrl: 'https://github.com/espython',
     liveUrl: '#',
+    featured: true,
   },
   {
     slug: 'project-two',
@@ -26,6 +20,7 @@ const FEATURED_PROJECTS: Project[] = [
       'An open-source CLI tool that automates repetitive development tasks and integrates with popular CI/CD pipelines.',
     tags: ['Node.js', 'CLI', 'CI/CD'],
     githubUrl: 'https://github.com/espython',
+    featured: true,
   },
   {
     slug: 'project-three',
@@ -35,6 +30,7 @@ const FEATURED_PROJECTS: Project[] = [
     tags: ['React', 'WebSockets', 'Tailwind CSS'],
     githubUrl: 'https://github.com/espython',
     liveUrl: '#',
+    featured: true,
   },
 ]
 

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,11 @@
+export interface Project {
+  slug: string
+  title: string
+  description: string
+  longDescription?: string
+  tags: string[]
+  githubUrl?: string
+  liveUrl?: string
+  featured: boolean
+  coverImage?: string
+}


### PR DESCRIPTION
## Summary
- Add `src/types/project.ts` with the shared `Project` interface
- Update `FeaturedProjects` to import from the shared type instead of a local interface

Closes #42

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] No lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)