### PR TITLE
feat: build /projects list page

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,35 @@
+import { type Metadata } from 'next'
+
+import { ProjectCard } from '@/components/projects/ProjectCard'
+import { projects } from '@/data/projects'
+
+export const metadata: Metadata = {
+  title: 'Projects',
+  description: 'A collection of projects I have built.',
+}
+
+export default function ProjectsPage() {
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-20">
+      <div className="mb-12">
+        <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+          My Work
+        </p>
+        <h1 className="text-4xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-5xl">
+          Projects
+        </h1>
+        <p className="mt-4 max-w-2xl text-lg text-[var(--color-text-muted)]">
+          Things I&apos;ve built — from side projects to open-source tools.
+        </p>
+      </div>
+
+      <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {projects.map((project) => (
+          <li key={project.slug}>
+            <ProjectCard project={project} />
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `app/projects/page.tsx` with page heading and a 3-column `ProjectCard` grid showing all projects

Closes #45

## Test plan
- [ ] `/projects` renders all 4 projects in light and dark mode
- [ ] Responsive grid: 1 col mobile, 2 tablet, 3 desktop
- [ ] No TypeScript or lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)