### PR TITLE
fix: auto-close issues on merge to develop

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -3,7 +3,7 @@ name: Auto-close linked issues on PR merge
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   auto-close:


### PR DESCRIPTION
## Summary
- Fix `auto-close.yml` to trigger on PRs merged into `develop` (was `main` only)
- Branch auto-delete already enabled via repo settings

## Why
Issues with `Closes #N` were not closing because the workflow only fired on merges to `main`, but feature PRs target `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)