### PR TITLE
feat: create lib/posts.ts utility and PostMeta type

### DIFF
--- a/src/components/home/LatestPosts.tsx
+++ b/src/components/home/LatestPosts.tsx
@@ -1,12 +1,6 @@
 import Link from 'next/link'
 
-interface PostMeta {
-  slug: string
-  title: string
-  date: string
-  summary: string
-  tags: string[]
-}
+import { type PostMeta } from '@/types/post'
 
 const LATEST_POSTS: PostMeta[] = [
   {

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,60 @@
+import fs from 'fs'
+import path from 'path'
+
+import matter from 'gray-matter'
+import { remark } from 'remark'
+import remarkHtml from 'remark-html'
+
+import { type Post, type PostMeta } from '@/types/post'
+
+const postsDirectory = path.join(process.cwd(), 'posts')
+
+function getPostFiles(): string[] {
+  if (!fs.existsSync(postsDirectory)) return []
+  return fs.readdirSync(postsDirectory).filter((f) => f.endsWith('.md'))
+}
+
+export function getAllPostsMeta(): PostMeta[] {
+  const files = getPostFiles()
+
+  const posts = files.map((filename) => {
+    const slug = filename.replace(/\.md$/, '')
+    const fullPath = path.join(postsDirectory, filename)
+    const fileContents = fs.readFileSync(fullPath, 'utf8')
+    const { data } = matter(fileContents)
+
+    return {
+      slug,
+      title: data.title as string,
+      date: data.date as string,
+      summary: data.summary as string,
+      tags: (data.tags as string[]) ?? [],
+    }
+  })
+
+  return posts.sort((a, b) => (a.date < b.date ? 1 : -1))
+}
+
+export async function getPostBySlug(slug: string): Promise<Post | null> {
+  const fullPath = path.join(postsDirectory, `${slug}.md`)
+  if (!fs.existsSync(fullPath)) return null
+
+  const fileContents = fs.readFileSync(fullPath, 'utf8')
+  const { data, content } = matter(fileContents)
+
+  const processed = await remark().use(remarkHtml).process(content)
+  const contentHtml = processed.toString()
+
+  return {
+    slug,
+    title: data.title as string,
+    date: data.date as string,
+    summary: data.summary as string,
+    tags: (data.tags as string[]) ?? [],
+    contentHtml,
+  }
+}
+
+export function getAllPostSlugs(): string[] {
+  return getPostFiles().map((f) => f.replace(/\.md$/, ''))
+}

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,11 @@
+export interface PostMeta {
+  slug: string
+  title: string
+  date: string
+  summary: string
+  tags: string[]
+}
+
+export interface Post extends PostMeta {
+  contentHtml: string
+}


### PR DESCRIPTION
## Summary
- Add `src/types/post.ts` with `PostMeta` and `Post` interfaces
- Add `src/lib/posts.ts` with `getAllPostsMeta`, `getPostBySlug`, `getAllPostSlugs`
- Update `LatestPosts` to import the shared `PostMeta` type

Closes #48

## Test plan
- [ ] No TypeScript or lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)