### PR TITLE
feat: add sample blog posts

### DIFF
--- a/posts/getting-started-with-nextjs-15.md
+++ b/posts/getting-started-with-nextjs-15.md
@@ -1,0 +1,51 @@
+---
+title: Getting Started with Next.js 15
+date: '2026-03-20'
+summary: A deep dive into what changed in Next.js 15 — new APIs, breaking changes, and how to migrate your existing app.
+tags:
+  - Next.js
+  - React
+---
+
+Next.js 15 ships with a set of breaking changes that are easy to miss if you're upgrading from v14. This post covers what changed, what to watch out for, and how to make your migration smooth.
+
+## What's New
+
+### `params` is Now a Promise
+
+The most impactful change for App Router users: `params` and `searchParams` are now asynchronous. You must `await` them before accessing values.
+
+```tsx
+// Before (Next.js 14)
+export default function Page({ params }: { params: { slug: string } }) {
+  return <h1>{params.slug}</h1>
+}
+
+// After (Next.js 15)
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  return <h1>{slug}</h1>
+}
+```
+
+### Turbopack is Now Stable for `next dev`
+
+Turbopack graduates from beta. You get significantly faster HMR out of the box — no config needed.
+
+### `fetch` Caching Defaults Changed
+
+Fetch requests are **no longer cached by default**. To cache, you must explicitly opt in:
+
+```ts
+const data = await fetch('/api/data', { cache: 'force-cache' })
+```
+
+## Migration Checklist
+
+- Update all `params` and `searchParams` accesses to use `await`
+- Review any `fetch` calls that relied on default caching
+- Run `next lint` — the new ESLint rules will catch most issues
+
+## Conclusion
+
+Next.js 15 is a worthwhile upgrade. The async params change feels jarring at first, but it enables better streaming and caching primitives down the line.

--- a/posts/mastering-tailwind-css-v4.md
+++ b/posts/mastering-tailwind-css-v4.md
@@ -1,0 +1,51 @@
+---
+title: Mastering Tailwind CSS v4
+date: '2026-03-10'
+summary: Tailwind v4 rewrites the engine from scratch. Here is what the new CSS-first config means for your workflow.
+tags:
+  - CSS
+  - Tailwind
+---
+
+Tailwind CSS v4 is a ground-up rewrite. The JavaScript config file is gone — configuration now lives in CSS using `@theme`. This post walks through the key changes and how to adapt your workflow.
+
+## The New CSS-First Config
+
+Instead of `tailwind.config.js`, you configure Tailwind inside your CSS file:
+
+```css
+@import 'tailwindcss';
+
+@theme {
+  --color-primary: #6366f1;
+  --font-sans: 'Inter', ui-sans-serif;
+  --spacing-18: 4.5rem;
+}
+```
+
+Every `--variable` you define under `@theme` automatically becomes a utility class. `--color-primary` generates `bg-primary`, `text-primary`, `border-primary`, and so on.
+
+## Design Tokens as CSS Variables
+
+Your theme values are now real CSS custom properties on `:root`. That means you can read them in JavaScript, use them in `style` props, and override them per-component with a wrapping selector — no Tailwind plugins needed.
+
+```tsx
+<div style={{ color: 'var(--color-primary)' }}>Hello</div>
+```
+
+## What Stayed the Same
+
+- All the utility classes you know work exactly the same
+- `@apply` still works
+- The JIT engine is still there (faster than ever)
+
+## Migration Tips
+
+1. Delete `tailwind.config.js` and `postcss.config.js`
+2. Move theme values into `@theme {}` in your CSS
+3. Replace `theme('colors.primary')` in CSS with `var(--color-primary)`
+4. Run `npx tailwindcss upgrade` to auto-migrate most of the syntax
+
+## Conclusion
+
+The CSS-first approach aligns Tailwind with the direction the web platform is heading. Once you internalize that your theme _is_ CSS variables, v4 feels like a natural evolution.


### PR DESCRIPTION
## Summary
- Add `posts/getting-started-with-nextjs-15.md` and `posts/mastering-tailwind-css-v4.md`
- Both include full frontmatter (title, date, summary, tags) and meaningful content

Closes #49
Closes #50

## Test plan
- [ ] `getAllPostsMeta()` returns both posts sorted by date
- [ ] No lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)