### PR TITLE
feat: add syntax highlighting to code blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,12 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "rehype-pretty-code": "^0.14.3",
+        "rehype-stringify": "^10.0.1",
         "remark": "^15.0.1",
-        "remark-html": "^16.0.1"
+        "remark-html": "^16.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "unified": "^11.0.5"
       },
       "devDependencies": {
         "@netlify/plugin-nextjs": "^5.15.9",
@@ -6997,6 +7001,21 @@
         "shiki": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
@@ -7040,6 +7059,23 @@
         "mdast-util-from-markdown": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,12 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "rehype-pretty-code": "^0.14.3",
+    "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",
-    "remark-html": "^16.0.1"
+    "remark-html": "^16.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "unified": "^11.0.5"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,6 +43,22 @@
   --color-text-subtle: var(--color-text-subtle);
 }
 
+/* ── Syntax highlighting (rehype-pretty-code) ───────────────── */
+[data-rehype-pretty-code-figure] pre {
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.75rem;
+  overflow-x: auto;
+  font-size: 0.875rem;
+  line-height: 1.7;
+  border: 1px solid var(--color-border);
+}
+
+[data-rehype-pretty-code-figure] code {
+  background: none;
+  padding: 0;
+  font-size: inherit;
+}
+
 /* ── Base ───────────────────────────────────────────────────── */
 html {
   scroll-behavior: smooth;

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -2,8 +2,11 @@ import fs from 'fs'
 import path from 'path'
 
 import matter from 'gray-matter'
-import { remark } from 'remark'
-import remarkHtml from 'remark-html'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import rehypePrettyCode from 'rehype-pretty-code'
+import rehypeStringify from 'rehype-stringify'
 
 import { type Post, type PostMeta } from '@/types/post'
 
@@ -42,7 +45,19 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
   const fileContents = fs.readFileSync(fullPath, 'utf8')
   const { data, content } = matter(fileContents)
 
-  const processed = await remark().use(remarkHtml).process(content)
+  const processed = await unified()
+    .use(remarkParse)
+    .use(remarkRehype)
+    .use(rehypePrettyCode, {
+      theme: {
+        dark: 'github-dark',
+        light: 'github-light',
+      },
+      keepBackground: false,
+    })
+    .use(rehypeStringify)
+    .process(content)
+
   const contentHtml = processed.toString()
 
   return {


### PR DESCRIPTION
## Summary
- Replace `remark` + `remark-html` with a full unified pipeline: `remark-parse` → `remark-rehype` → `rehype-pretty-code` → `rehype-stringify`
- Use `github-dark` / `github-light` dual themes with `keepBackground: false`
- Add base CSS for code block padding, border-radius, and border

Closes #54

## Test plan
- [ ] Code blocks in blog posts are syntax highlighted
- [ ] Light/dark themes switch correctly with dark mode toggle
- [ ] No TypeScript or lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)