### PR TITLE
feat: build experience/timeline section on About page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,14 +1,18 @@
 import { type Metadata } from 'next'
 
+import { ExperienceTimeline } from '@/components/about/ExperienceTimeline'
+
 export const metadata: Metadata = {
   title: 'About',
-  description: 'Learn more about who I am, what I do, and the tools I work with.',
+  description:
+    'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications.',
 }
 
 export default function AboutPage() {
   return (
     <main>
       <HeroBio />
+      <ExperienceTimeline />
     </main>
   )
 }

--- a/src/components/about/ExperienceTimeline.tsx
+++ b/src/components/about/ExperienceTimeline.tsx
@@ -1,0 +1,134 @@
+interface Role {
+  title: string
+  company: string
+  period: string
+  location: string
+  highlights: string[]
+  tags: string[]
+}
+
+const EXPERIENCE: Role[] = [
+  {
+    title: 'Senior Software Engineer',
+    company: 'VOIS (Vodafone Intelligent Solutions)',
+    period: 'Present',
+    location: 'Remote',
+    highlights: [
+      'Building scalable enterprise-grade applications in a cross-functional agile team.',
+      'Leading frontend architecture decisions and conducting code reviews.',
+    ],
+    tags: ['TypeScript', 'React.js', 'Node.js'],
+  },
+  {
+    title: 'Senior Frontend Engineer',
+    company: 'InVitro Capital',
+    period: 'Nov 2024 – Present',
+    location: 'Irvine, CA — Remote',
+    highlights: [
+      'Architected complex, performant React/TypeScript applications with advanced state management.',
+      'Designed scalable AWS microservices (Lambda, CloudFront, S3, RDS, ECS).',
+      'Improved performance monitoring via CloudWatch and enforced granular IAM access control.',
+    ],
+    tags: ['React.js', 'Next.js', 'TypeScript', 'AWS', 'Node.js'],
+  },
+  {
+    title: 'Senior Full Stack Engineer',
+    company: 'Swenson He LLC',
+    period: 'May 2023 – Jun 2024',
+    location: 'Los Angeles, CA — Remote',
+    highlights: [
+      'Reduced infrastructure costs by 40% via AWS Lambda serverless architecture.',
+      'Designed CI/CD pipelines with GitHub Actions integrated with AWS Elastic Beanstalk.',
+      'Built secure auth systems (JWT, OAuth) and robust notification pipelines (SNS, SES).',
+    ],
+    tags: ['Node.js', 'Nest.js', 'React.js', 'AWS', 'PostgreSQL'],
+  },
+  {
+    title: 'Full Stack Developer',
+    company: 'DotOffice VB',
+    period: 'Nov 2021 – May 2023',
+    location: 'Amsterdam, Netherlands — Remote',
+    highlights: [
+      'Built a cloud-based document management platform on Azure VMs with Azure Functions.',
+      'Implemented Azure Active Directory for authentication and Azure Blob Storage for assets.',
+      'Designed MSSQL schemas and applied React performance patterns (code splitting, memoization).',
+    ],
+    tags: ['TypeScript', 'React.js', 'C#', 'ASP.NET', 'Azure', 'MSSQL'],
+  },
+  {
+    title: 'Software Engineer',
+    company: 'HyperList LLC',
+    period: 'Jun 2019 – Nov 2021',
+    location: 'Riyadh, KSA — Remote',
+    highlights: [
+      'Built scalable e-learning platforms on Google Cloud Platform with microservices architecture.',
+      'Developed a cross-platform iOS app with React Native.',
+      'Reduced load times by 35% through debugging and performance optimisation.',
+    ],
+    tags: ['React.js', 'React Native', 'Node.js', 'GCP'],
+  },
+  {
+    title: 'Frontend Developer',
+    company: 'Arabic Digital Research Institute',
+    period: 'Apr 2018 – Jun 2019',
+    location: 'Manama, Bahrain — Remote',
+    highlights: [
+      'Contributed to an AI-driven research platform using React.js and Ember.js.',
+      'Conducted code reviews and developed unit tests for UI components.',
+    ],
+    tags: ['React.js', 'Ember.js', 'JavaScript'],
+  },
+]
+
+export function ExperienceTimeline() {
+  return (
+    <section className="mx-auto max-w-4xl px-6 py-20">
+      <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+        Career
+      </p>
+      <h2 className="mb-12 text-3xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-4xl">
+        Experience
+      </h2>
+
+      <ol className="relative border-l border-[var(--color-border)]">
+        {EXPERIENCE.map((role, i) => (
+          <li key={i} className="mb-12 ml-6 last:mb-0">
+            {/* Timeline dot */}
+            <span className="absolute -left-[9px] flex h-4 w-4 items-center justify-center rounded-full bg-[var(--color-primary)] ring-4 ring-[var(--color-bg)]" />
+
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-[var(--color-text)]">{role.title}</h3>
+                <p className="text-sm font-medium text-[var(--color-primary)]">{role.company}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-sm text-[var(--color-text-muted)]">{role.period}</p>
+                <p className="text-xs text-[var(--color-text-subtle)]">{role.location}</p>
+              </div>
+            </div>
+
+            <ul className="mt-3 space-y-1.5">
+              {role.highlights.map((point, j) => (
+                <li key={j} className="flex gap-2 text-sm text-[var(--color-text-muted)]">
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-primary)]" />
+                  {point}
+                </li>
+              ))}
+            </ul>
+
+            <div className="mt-3 flex flex-wrap gap-2">
+              {role.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-md bg-[var(--color-bg-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-muted)]"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `ExperienceTimeline` component with a vertical timeline of all 6 roles (VOIS, InVitro Capital, Swenson He LLC, DotOffice VB, HyperList LLC, ADRI)
- Each entry includes title, company, period, location, bullet highlights, and tech tags
- Wire into `app/about/page.tsx`

Closes #59

## Test plan
- [ ] Timeline renders correctly in light and dark mode
- [ ] Responsive layout on mobile and desktop
- [ ] No TypeScript or lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)