### PR TITLE
feat: add client-side form validation to contact form

### DIFF
--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -11,23 +11,65 @@ interface FormFields {
   message: string
 }
 
+type FormErrors = Partial<Record<keyof FormFields, string>>
+
 const EMPTY: FormFields = { name: '', email: '', subject: '', message: '' }
+
+function validate(fields: FormFields): FormErrors {
+  const errors: FormErrors = {}
+  if (!fields.name.trim()) errors.name = 'Name is required.'
+  if (!fields.email.trim()) {
+    errors.email = 'Email is required.'
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fields.email)) {
+    errors.email = 'Please enter a valid email address.'
+  }
+  if (!fields.subject.trim()) errors.subject = 'Subject is required.'
+  if (!fields.message.trim()) {
+    errors.message = 'Message is required.'
+  } else if (fields.message.trim().length < 10) {
+    errors.message = 'Message must be at least 10 characters.'
+  }
+  return errors
+}
 
 export function ContactForm() {
   const [fields, setFields] = useState<FormFields>(EMPTY)
+  const [errors, setErrors] = useState<FormErrors>({})
+  const [touched, setTouched] = useState<Partial<Record<keyof FormFields, boolean>>>({})
   const [status, setStatus] = useState<FormState>('idle')
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
-    setFields((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+    const { name, value } = e.target
+    setFields((prev) => ({ ...prev, [name]: value }))
+    if (touched[name as keyof FormFields]) {
+      setErrors((prev) => ({
+        ...prev,
+        [name]: validate({ ...fields, [name]: value })[name as keyof FormFields],
+      }))
+    }
+  }
+
+  function handleBlur(e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    const { name } = e.target
+    setTouched((prev) => ({ ...prev, [name]: true }))
+    setErrors((prev) => ({ ...prev, [name]: validate(fields)[name as keyof FormFields] }))
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    const allTouched = { name: true, email: true, subject: true, message: true }
+    setTouched(allTouched)
+    const validationErrors = validate(fields)
+    setErrors(validationErrors)
+    if (Object.keys(validationErrors).length > 0) return
+
     setStatus('submitting')
-    // Submission logic will be wired in #62
+    // Submission will be wired in #62
     await new Promise((r) => setTimeout(r, 800))
     setStatus('success')
     setFields(EMPTY)
+    setTouched({})
+    setErrors({})
   }
 
   return (
@@ -38,7 +80,9 @@ export function ContactForm() {
           name="name"
           type="text"
           value={fields.name}
+          error={touched.name ? errors.name : undefined}
           onChange={handleChange}
+          onBlur={handleBlur}
           required
         />
         <Field
@@ -46,7 +90,9 @@ export function ContactForm() {
           name="email"
           type="email"
           value={fields.email}
+          error={touched.email ? errors.email : undefined}
           onChange={handleChange}
+          onBlur={handleBlur}
           required
         />
       </div>
@@ -55,9 +101,13 @@ export function ContactForm() {
         name="subject"
         type="text"
         value={fields.subject}
+        error={touched.subject ? errors.subject : undefined}
         onChange={handleChange}
+        onBlur={handleBlur}
         required
       />
+
+      {/* Message textarea */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="message" className="text-sm font-medium text-[var(--color-text)]">
           Message <span className="text-[var(--color-primary)]">*</span>
@@ -66,12 +116,22 @@ export function ContactForm() {
           id="message"
           name="message"
           rows={6}
-          required
           value={fields.message}
           onChange={handleChange}
+          onBlur={handleBlur}
           placeholder="Your message…"
-          className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20 resize-none"
+          aria-describedby={errors.message ? 'message-error' : undefined}
+          className={`resize-none rounded-lg border bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:ring-2 focus:ring-[var(--color-primary)]/20 ${
+            touched.message && errors.message
+              ? 'border-red-500 focus:border-red-500'
+              : 'border-[var(--color-border)] focus:border-[var(--color-primary)]'
+          }`}
         />
+        {touched.message && errors.message && (
+          <p id="message-error" className="text-xs text-red-500">
+            {errors.message}
+          </p>
+        )}
       </div>
 
       <button
@@ -101,11 +161,14 @@ interface FieldProps {
   name: string
   type: string
   value: string
+  error?: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onBlur: (e: React.FocusEvent<HTMLInputElement>) => void
   required?: boolean
 }
 
-function Field({ label, name, type, value, onChange, required }: FieldProps) {
+function Field({ label, name, type, value, error, onChange, onBlur, required }: FieldProps) {
+  const errorId = `${name}-error`
   return (
     <div className="flex flex-col gap-1.5">
       <label htmlFor={name} className="text-sm font-medium text-[var(--color-text)]">
@@ -115,12 +178,23 @@ function Field({ label, name, type, value, onChange, required }: FieldProps) {
         id={name}
         name={name}
         type={type}
-        required={required}
         value={value}
         onChange={onChange}
+        onBlur={onBlur}
         placeholder={label}
-        className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20"
+        aria-describedby={error ? errorId : undefined}
+        aria-invalid={!!error}
+        className={`rounded-lg border bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:ring-2 focus:ring-[var(--color-primary)]/20 ${
+          error
+            ? 'border-red-500 focus:border-red-500'
+            : 'border-[var(--color-border)] focus:border-[var(--color-primary)]'
+        }`}
       />
+      {error && (
+        <p id={errorId} className="text-xs text-red-500">
+          {error}
+        </p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add `validate()` with rules: required fields, email format, message min length (10 chars)
- Errors shown on blur (per field) and on submit attempt
- Invalid fields highlighted with red border
- Accessible: `aria-invalid`, `aria-describedby` on each field

Closes #61

## Test plan
- [ ] Submitting empty form shows all errors
- [ ] Invalid email shows format error
- [ ] Short message shows min-length error
- [ ] Errors clear as user fixes each field
- [ ] No TypeScript or lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)