### PR TITLE
feat: add success/error toast on contact form submit

### DIFF
--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
+
+import { Toast } from '@/components/ui/Toast'
 
 type FormState = 'idle' | 'submitting' | 'success' | 'error'
 
@@ -37,6 +39,8 @@ export function ContactForm() {
   const [errors, setErrors] = useState<FormErrors>({})
   const [touched, setTouched] = useState<Partial<Record<keyof FormFields, boolean>>>({})
   const [status, setStatus] = useState<FormState>('idle')
+  const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
+  const dismissToast = useCallback(() => setToast(null), [])
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     const { name, value } = e.target
@@ -75,8 +79,13 @@ export function ContactForm() {
       setFields(EMPTY)
       setTouched({})
       setErrors({})
+      setToast({ type: 'success', message: "Message sent! I'll get back to you soon." })
     } catch {
       setStatus('error')
+      setToast({
+        type: 'error',
+        message: 'Something went wrong. Please try again or email me directly.',
+      })
     }
   }
 
@@ -150,16 +159,7 @@ export function ContactForm() {
         {status === 'submitting' ? 'Sending…' : 'Send Message'}
       </button>
 
-      {status === 'success' && (
-        <p className="rounded-lg bg-green-50 px-4 py-3 text-sm font-medium text-green-700 dark:bg-green-950/30 dark:text-green-400">
-          Message sent! I&apos;ll get back to you soon.
-        </p>
-      )}
-      {status === 'error' && (
-        <p className="rounded-lg bg-red-50 px-4 py-3 text-sm font-medium text-red-700 dark:bg-red-950/30 dark:text-red-400">
-          Something went wrong. Please try again or email me directly.
-        </p>
-      )}
+      {toast && <Toast type={toast.type} message={toast.message} onClose={dismissToast} />}
     </form>
   )
 }

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect } from 'react'
+
+type ToastType = 'success' | 'error'
+
+interface ToastProps {
+  type: ToastType
+  message: string
+  onClose: () => void
+  duration?: number
+}
+
+export function Toast({ type, message, onClose, duration = 4000 }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, duration)
+    return () => clearTimeout(timer)
+  }, [onClose, duration])
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className={`fixed bottom-6 right-6 z-50 flex items-start gap-3 rounded-xl px-5 py-4 shadow-lg transition-all ${
+        type === 'success'
+          ? 'bg-green-50 text-green-800 ring-1 ring-green-200 dark:bg-green-950/60 dark:text-green-300 dark:ring-green-800'
+          : 'bg-red-50 text-red-800 ring-1 ring-red-200 dark:bg-red-950/60 dark:text-red-300 dark:ring-red-800'
+      }`}
+    >
+      <span className="mt-0.5 text-lg leading-none" aria-hidden>
+        {type === 'success' ? '✓' : '✕'}
+      </span>
+      <p className="text-sm font-medium">{message}</p>
+      <button
+        onClick={onClose}
+        aria-label="Dismiss"
+        className="ml-2 text-current opacity-50 transition-opacity hover:opacity-100"
+      >
+        ✕
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `Toast` component — fixed bottom-right, auto-dismisses after 4s, accessible `role="alert"`
- Replace inline success/error paragraphs in `ContactForm` with the Toast

Closes #63

## Test plan
- [ ] Success toast appears after form submit
- [ ] Error toast appears on failure
- [ ] Toast auto-dismisses after 4 seconds
- [ ] Manual dismiss (✕ button) works
- [ ] No TypeScript or lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)