### PR TITLE
feat: add full metadata and OpenGraph tags to all pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,6 +6,12 @@ export const metadata: Metadata = {
   title: 'About',
   description:
     'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications.',
+  openGraph: {
+    url: '/about',
+    title: 'About — Eslam Mahmoud',
+    description:
+      'Full Stack Software Engineer with 6+ years of experience. Currently Senior Engineer at VOIS (Vodafone Intelligent Solutions).',
+  },
 }
 
 export default function AboutPage() {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -19,6 +19,15 @@ export async function generateMetadata({
   return {
     title: post.title,
     description: post.summary,
+    openGraph: {
+      url: `/blog/${slug}`,
+      title: post.title,
+      description: post.summary,
+      type: 'article',
+      publishedTime: post.date,
+      tags: post.tags,
+    },
+    twitter: { card: 'summary_large_image', title: post.title, description: post.summary },
   }
 }
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -6,6 +6,12 @@ import { getAllPostsMeta } from '@/lib/posts'
 export const metadata: Metadata = {
   title: 'Blog',
   description: 'Thoughts on web development, TypeScript, and building things.',
+  openGraph: {
+    url: '/blog',
+    title: 'Blog — Eslam Mahmoud',
+    description:
+      'Thoughts on web development, TypeScript, React, and things I learn along the way.',
+  },
 }
 
 export default function BlogPage() {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,6 +5,12 @@ import { ContactForm } from '@/components/contact/ContactForm'
 export const metadata: Metadata = {
   title: 'Contact',
   description: 'Get in touch with Eslam Mahmoud — open to new opportunities and collaborations.',
+  openGraph: {
+    url: '/contact',
+    title: 'Contact — Eslam Mahmoud',
+    description:
+      'Get in touch — open to new opportunities, collaborations, or a friendly chat about tech.',
+  },
 }
 
 export default function ContactPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,12 +12,35 @@ const inter = Inter({
   display: 'swap',
 })
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://espython.dev'
+const SITE_NAME = 'Eslam Mahmoud'
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: 'YourName.dev',
-    template: '%s | YourName.dev',
+    default: `${SITE_NAME} — Full Stack Engineer`,
+    template: `%s | ${SITE_NAME}`,
   },
-  description: 'Full-stack developer portfolio and blog.',
+  description:
+    'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications with React, Node.js, and AWS.',
+  authors: [{ name: SITE_NAME }],
+  keywords: ['Full Stack Engineer', 'React', 'TypeScript', 'Node.js', 'AWS', 'Next.js'],
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    locale: 'en_US',
+    url: SITE_URL,
+    title: `${SITE_NAME} — Full Stack Engineer`,
+    description:
+      'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${SITE_NAME} — Full Stack Engineer`,
+    description:
+      'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications.',
+  },
+  robots: { index: true, follow: true },
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,15 @@
+import { type Metadata } from 'next'
+
 import { Hero } from '@/components/home/Hero'
+
+export const metadata: Metadata = {
+  openGraph: {
+    url: '/',
+    title: 'Eslam Mahmoud — Full Stack Engineer',
+    description:
+      'Portfolio and blog of Eslam Mahmoud — Full Stack Software Engineer specializing in React, Node.js, and AWS.',
+  },
+}
 import { FeaturedProjects } from '@/components/home/FeaturedProjects'
 import { LatestPosts } from '@/components/home/LatestPosts'
 import { CallToAction } from '@/components/home/CallToAction'

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -19,6 +19,16 @@ export async function generateMetadata({
   return {
     title: project.title,
     description: project.description,
+    openGraph: {
+      url: `/projects/${slug}`,
+      title: project.title,
+      description: project.description,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: project.title,
+      description: project.description,
+    },
   }
 }
 

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -6,6 +6,12 @@ import { projects } from '@/data/projects'
 export const metadata: Metadata = {
   title: 'Projects',
   description: 'A collection of projects I have built.',
+  openGraph: {
+    url: '/projects',
+    title: 'Projects — Eslam Mahmoud',
+    description:
+      'Full-stack and open-source projects built with React, Node.js, TypeScript, and AWS.',
+  },
 }
 
 export default function ProjectsPage() {


### PR DESCRIPTION
## Summary
- Root layout: add `metadataBase`, `keywords`, `authors`, full `openGraph` and `twitter` defaults
- Homepage, /about, /blog, /projects, /contact: add `openGraph` with page-specific URLs and descriptions
- `/blog/[slug]`: add OG `article` type with `publishedTime` and `tags`
- `/projects/[slug]`: add OG and Twitter card

Closes #64

## Test plan
- [ ] `<title>` and `<meta description>` correct on all pages
- [ ] OG tags visible in link previews
- [ ] No TypeScript or lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)