### PR TITLE
feat: add sitemap.xml

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,59 @@
+import type { MetadataRoute } from 'next'
+
+import { getAllPostsMeta } from '@/lib/posts'
+import { projects } from '@/data/projects'
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://espython.dev'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const posts = getAllPostsMeta()
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/projects`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/blog`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/contact`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.5,
+    },
+  ]
+
+  const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${SITE_URL}/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+    changeFrequency: 'monthly',
+    priority: 0.7,
+  }))
+
+  const projectRoutes: MetadataRoute.Sitemap = projects.map((project) => ({
+    url: `${SITE_URL}/projects/${project.slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly',
+    priority: 0.6,
+  }))
+
+  return [...staticRoutes, ...postRoutes, ...projectRoutes]
+}


### PR DESCRIPTION
## Summary
- Add `app/sitemap.ts` with all static routes, blog posts (lastModified from post date), and project pages
- Served automatically at `/sitemap.xml` by Next.js

Closes #67

## Test plan
- [ ] `/sitemap.xml` returns valid XML with all routes
- [ ] No TypeScript or lint errors in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)