### PR TITLE
feat(seo): add robots.txt

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://espython.dev'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/'],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/app/robots.ts` using `MetadataRoute.Robots` (Next.js built-in)
- Allows all crawlers, disallows `/api/`, and links to the sitemap
- `NEXT_PUBLIC_SITE_URL` env var controls the base URL (falls back to `https://espython.dev`)

Closes #68

## Test plan
- [x] Build output shows `/robots.txt` as a static route
- [ ] `GET /robots.txt` returns correct `Disallow` and `Sitemap` directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)