### PR TITLE
fix(a11y): Lighthouse audit — dark-mode contrast + heading order

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,7 +28,7 @@
 
   --color-text: #f0f0f8;
   --color-text-muted: #9898b3;
-  --color-text-subtle: #52526e;
+  --color-text-subtle: #7878a0;
 }
 
 @theme inline {

--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -23,9 +23,9 @@ export function BlogPostCard({ post }: BlogPostCardProps) {
           <span>·</span>
           <span>{post.readingTime} min read</span>
         </div>
-        <h3 className="mb-2 text-lg font-semibold text-[var(--color-text)] transition-colors group-hover:text-[var(--color-primary)]">
+        <h2 className="mb-2 text-lg font-semibold text-[var(--color-text)] transition-colors group-hover:text-[var(--color-primary)]">
           {post.title}
-        </h3>
+        </h2>
         <p className="flex-1 text-sm leading-relaxed text-[var(--color-text-muted)]">
           {post.summary}
         </p>


### PR DESCRIPTION
## Summary
- `--color-text-subtle` in dark mode raised from `#52526e` (2.2:1 contrast) to `#7878a0` (≥4.7:1) — fixes date, meta, footer, location text contrast failures across all pages
- `BlogPostCard` heading changed from `h3` → `h2` to fix WCAG heading-order violation (page had `h1` → `h3`, skipping `h2`)

## Lighthouse scores (after)
| Page | Perf | A11y | Best Practices | SEO |
|------|------|------|----------------|-----|
| `/` | 97 | 95 | 100 | 100 |
| `/blog` | 97 | 95 | 100 | 100 |
| `/blog/[slug]` | 97 | 96 | 100 | 100 |

All scores ≥ 90 ✓

Closes #69

## Test plan
- [x] Build passes
- [x] Lighthouse run on `/`, `/blog`, `/blog/[slug]` — all categories ≥ 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)