### PR TITLE
fix(qa): viewport, brand placeholders, and social links

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
 import { ThemeProvider } from 'next-themes'
 
@@ -14,6 +14,15 @@ const inter = Inter({
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://espython.dev'
 const SITE_NAME = 'Eslam Mahmoud'
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#fafaff' },
+    { media: '(prefers-color-scheme: dark)', color: '#0a0a0f' },
+  ],
+}
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,8 +2,7 @@ import Link from 'next/link'
 
 const SOCIAL_LINKS = [
   { href: 'https://github.com/espython', label: 'GitHub' },
-  { href: 'https://linkedin.com/in/yourname', label: 'LinkedIn' },
-  { href: 'https://twitter.com/yourname', label: 'Twitter' },
+  { href: 'https://www.linkedin.com/in/eslam-mahmoud-a63b06116/', label: 'LinkedIn' },
 ]
 
 const NAV_LINKS = [
@@ -26,10 +25,10 @@ export function Footer() {
               href="/"
               className="text-base font-bold text-[var(--color-primary)] hover:opacity-80"
             >
-              YourName.dev
+              espython.dev
             </Link>
             <p className="mt-1 text-xs text-[var(--color-text-subtle)]">
-              Building things on the web.
+              Full Stack Engineer · Luxor, Egypt
             </p>
           </div>
 
@@ -65,7 +64,7 @@ export function Footer() {
         </div>
 
         <p className="mt-8 text-xs text-[var(--color-text-subtle)]">
-          © {year} YourName.dev — Built with Next.js & Tailwind CSS
+          © {year} Eslam Mahmoud — Built with Next.js &amp; Tailwind CSS
         </p>
       </div>
     </footer>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -29,7 +29,7 @@ export function Navbar() {
           href="/"
           className="text-lg font-bold text-[var(--color-primary)] transition-opacity hover:opacity-80"
         >
-          YourName.dev
+          espython.dev
         </Link>
 
         {/* Desktop links */}


### PR DESCRIPTION
## Summary
- Add explicit `Viewport` export to `layout.tsx` with `theme-color` for light/dark mode (improves mobile browser chrome tinting)
- Replace all `YourName.dev` placeholders with `espython.dev` in navbar and footer
- Footer copyright updated to `Eslam Mahmoud`
- Footer tagline updated to `Full Stack Engineer · Luxor, Egypt`
- Social links: real GitHub + LinkedIn URLs; removed Twitter placeholder

Closes #73

## Test plan
- [x] Build passes
- [ ] Verify navbar logo reads "espython.dev" on mobile and desktop
- [ ] Verify footer copyright and social links are correct
- [ ] Check mobile menu opens/closes correctly on iOS Safari and Chrome Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)