### PR TITLE
content: final content pass with real data

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -38,21 +38,24 @@ function HeroBio() {
             About Me
           </p>
           <h1 className="mb-4 text-4xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-5xl">
-            Hi, I&apos;m <span className="text-[var(--color-primary)]">YourName</span>
+            Hi, I&apos;m <span className="text-[var(--color-primary)]">Eslam</span>
           </h1>
           <div className="space-y-4 text-lg leading-relaxed text-[var(--color-text-muted)]">
             <p>
-              I&apos;m a full-stack developer based in —, passionate about building fast, accessible
-              web experiences. I work primarily with TypeScript, React, and Node.js, and I care
-              deeply about clean code and great developer experience.
+              I&apos;m a Senior Full Stack Engineer based in Luxor, Egypt, with 6+ years of
+              experience building scalable web and mobile applications. I work primarily with
+              TypeScript, React, Node.js, and AWS — and I care deeply about clean architecture,
+              performance, and great developer experience.
             </p>
             <p>
-              When I&apos;m not coding, you&apos;ll find me writing about things I&apos;ve learned,
-              contributing to open source, or exploring new tools that make development more
-              enjoyable.
+              Currently at VOIS (Vodafone Intelligent Solutions), where I work on large-scale web
+              products. Previously I&apos;ve built platforms at InVitro Capital, Swenson He,
+              DotOffice, HyperList, and ADRI — shipping everything from real estate marketplaces and
+              SaaS dashboards to open-source developer tooling.
             </p>
             <p>
-              I&apos;m currently open to new opportunities — feel free to{' '}
+              Outside of work I write about things I&apos;ve learned, contribute to open source, and
+              explore new tools that make development more enjoyable. Feel free to{' '}
               <a
                 href="/contact"
                 className="font-medium text-[var(--color-primary)] underline underline-offset-4 transition-colors hover:text-[var(--color-primary-hover)]"
@@ -74,7 +77,7 @@ function HeroBio() {
               GitHub
             </a>
             <a
-              href="https://linkedin.com/in/yourname"
+              href="https://www.linkedin.com/in/eslam-mahmoud-a63b06116/"
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-lg border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-text)] transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]"

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -8,13 +8,14 @@ export function Hero() {
       </p>
 
       <h1 className="text-4xl font-extrabold leading-tight tracking-tight text-[var(--color-text)] sm:text-5xl md:text-6xl">
-        YourName
-        <span className="block text-[var(--color-primary)]">Full-Stack Developer</span>
+        Eslam Mahmoud
+        <span className="block text-[var(--color-primary)]">Full Stack Engineer</span>
       </h1>
 
       <p className="max-w-2xl text-lg leading-relaxed text-[var(--color-text-muted)]">
-        I build fast, accessible web applications with modern tools. Passionate about clean code,
-        great UX, and sharing what I learn.
+        Senior Full Stack Engineer with 6+ years building scalable web applications. I work across
+        the stack with TypeScript, React, Node.js, and AWS — and care deeply about clean
+        architecture, performance, and developer experience.
       </p>
 
       <div className="flex flex-wrap gap-4 pt-2">
@@ -43,21 +44,12 @@ export function Hero() {
         </a>
         <span className="text-[var(--color-border)]">·</span>
         <a
-          href="https://linkedin.com/in/yourname"
+          href="https://www.linkedin.com/in/eslam-mahmoud-a63b06116/"
           target="_blank"
           rel="noopener noreferrer"
           className="text-sm text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
         >
           LinkedIn
-        </a>
-        <span className="text-[var(--color-border)]">·</span>
-        <a
-          href="https://twitter.com/yourname"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sm text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
-        >
-          Twitter
         </a>
       </div>
     </section>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -2,49 +2,49 @@ import { type Project } from '@/types/project'
 
 export const projects: Project[] = [
   {
-    slug: 'project-one',
-    title: 'Project One',
+    slug: 'strapi-firebase-auth',
+    title: 'Strapi Firebase Auth',
     description:
-      'A full-stack web application built with Next.js, TypeScript, and PostgreSQL. Focuses on performance and accessibility.',
+      'Open-source Strapi plugin that integrates Firebase Authentication — supports social providers, custom tokens, and role syncing.',
     longDescription:
-      'This project was born out of a need to manage complex data workflows in a team environment. It features role-based access control, real-time updates via Server-Sent Events, and a fully accessible UI built to WCAG 2.1 AA standards.',
-    tags: ['Next.js', 'TypeScript', 'PostgreSQL'],
-    githubUrl: 'https://github.com/espython',
-    liveUrl: '#',
-    featured: true,
-    coverImage: '/images/projects/project-one.png',
-  },
-  {
-    slug: 'project-two',
-    title: 'Project Two',
-    description:
-      'An open-source CLI tool that automates repetitive development tasks and integrates with popular CI/CD pipelines.',
-    longDescription:
-      'Built to eliminate the boilerplate overhead in day-to-day development. Supports plugins, custom templates, and hooks. Integrates with GitHub Actions, GitLab CI, and CircleCI out of the box.',
-    tags: ['Node.js', 'CLI', 'CI/CD'],
-    githubUrl: 'https://github.com/espython',
+      'Published on the official Strapi Marketplace. Enables Firebase Authentication in any Strapi v4 application. Supports multiple social providers (Google, Facebook, Apple), custom token flows, and automatic Strapi role assignment based on Firebase claims. Used by teams who need a headless CMS with a modern auth layer without rolling their own.',
+    tags: ['Node.js', 'Strapi', 'Firebase', 'Open Source'],
+    githubUrl: 'https://github.com/swensonhe/strapi-firebase-auth',
+    liveUrl: 'https://market.strapi.io/plugins/@swensonhe-strapi-plugin-firebase-auth',
     featured: true,
   },
   {
-    slug: 'project-three',
-    title: 'Project Three',
+    slug: 'mcmakler',
+    title: 'McMakler',
     description:
-      'A real-time dashboard for monitoring system metrics, built with WebSockets and React.',
+      "Germany's leading digital real estate platform — connecting buyers, sellers, and agents through a seamless online experience.",
     longDescription:
-      'Streams live CPU, memory, and network metrics from a Node.js agent to a React dashboard over WebSockets. Supports configurable alerting thresholds and historical charting.',
-    tags: ['React', 'WebSockets', 'Tailwind CSS'],
-    githubUrl: 'https://github.com/espython',
-    liveUrl: '#',
+      "McMakler is one of Germany's largest PropTech companies, offering a hybrid real estate service that combines an online platform with local agents. Contributed to the platform's web frontend, focusing on listing search, property detail pages, and agent-facing tools.",
+    tags: ['React', 'TypeScript', 'Web'],
+    liveUrl: 'https://www.mcmakler.de/',
     featured: true,
   },
   {
-    slug: 'project-four',
-    title: 'Project Four',
-    description: 'A markdown-based static site generator with a focus on developer experience.',
+    slug: 'do365',
+    title: 'do365',
+    description:
+      'Cloud-based template management for Office 365 — Word, Outlook, PowerPoint, and Excel — built with React, Node.js, C#, and .NET.',
     longDescription:
-      'A lightweight static site generator that transforms Markdown + frontmatter into a production-ready site. Supports custom themes, syntax highlighting, and incremental builds.',
-    tags: ['TypeScript', 'Markdown', 'Node.js'],
-    githubUrl: 'https://github.com/espython',
+      'do365 lets organisations manage, distribute, and enforce branded document templates across Office 365 apps. The system integrates with Microsoft Graph to push templates directly into users&apos; Office applications. Built with a React frontend, Node.js API layer, and a C#/.NET backend handling authentication and template rendering.',
+    tags: ['React', 'Node.js', 'C#', '.NET', 'Office 365'],
+    liveUrl: 'https://www.do365.nl',
+    featured: true,
+  },
+  {
+    slug: 'portfolio-blog',
+    title: 'espython.dev',
+    description:
+      'This site — a portfolio and blog built with Next.js 16, TypeScript, Tailwind CSS v4, and Netlify.',
+    longDescription:
+      'Designed and built from scratch with a focus on performance and accessibility. Features a statically generated blog backed by Markdown files, dynamic OG images, a contact form powered by Resend, and a perfect Lighthouse score across all pages.',
+    tags: ['Next.js', 'TypeScript', 'Tailwind CSS', 'Netlify'],
+    githubUrl: 'https://github.com/espython/portfolio-blog',
+    liveUrl: 'https://espython.dev',
     featured: false,
   },
 ]


### PR DESCRIPTION
## Summary
Replaces all placeholder content with real data.

**Hero**
- Name → Eslam Mahmoud, title → Full Stack Engineer
- Real bio copy reflecting 6+ years, TypeScript/React/Node.js/AWS
- Real LinkedIn URL; Twitter placeholder removed

**About page**
- Real bio paragraph (Senior at VOIS, past companies, Luxor Egypt)
- Real LinkedIn URL

**Projects** — all four placeholder cards replaced:
| Slug | Project | Links |
|---|---|---|
| `strapi-firebase-auth` | Open-source Strapi Firebase Auth plugin | GitHub + Strapi Marketplace |
| `mcmakler` | McMakler German real estate platform | Live |
| `do365` | do365 Office 365 template management | Live |
| `portfolio-blog` | This site | GitHub + Live |

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)