### PR TITLE
release: merge develop into main — full site complete (M0–M9)

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -3,7 +3,7 @@ name: Auto-close linked issues on PR merge
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   auto-close:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   ci:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,14 +14,9 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npm run build
-      - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v3
-        with:
-          publish-dir: .next
-          production-branch: main
-          production-deploy: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm install -g netlify-cli
+      - name: Deploy to Netlify (production)
+        run: netlify deploy --build --prod --message "Deploy from main (${{ github.sha }})"
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,13 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3
         with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prod'
+          publish-dir: .next
+          production-branch: main
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,15 +14,22 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npm run build
+      - run: npm install -g netlify-cli
       - name: Deploy Preview to Netlify
-        uses: nwtgck/actions-netlify@v3
-        with:
-          publish-dir: .next
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
-          enable-pull-request-comment: true
-          enable-commit-comment: false
+        id: netlify
+        run: |
+          OUTPUT=$(netlify deploy --build --message "PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}" --json)
+          echo "url=$(echo $OUTPUT | jq -r '.deploy_url')" >> $GITHUB_OUTPUT
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### Netlify Preview\n🔗 ${{ steps.netlify.outputs.url }}`
+            })

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,8 @@
-name: Vercel Preview Deployment
+name: Netlify Preview Deployment
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   preview:
@@ -15,11 +15,14 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
-      - name: Deploy Preview to Vercel
-        uses: amondnet/vercel-action@v25
+      - name: Deploy Preview to Netlify
+        uses: nwtgck/actions-netlify@v3
         with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          publish-dir: .next
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          github-comment: true
+          deploy-message: "PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/README.md
+++ b/README.md
@@ -1,36 +1,148 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# espython.dev — Portfolio & Blog
 
-## Getting Started
+Personal portfolio and blog of Eslam Mahmoud, built with Next.js, TypeScript, and Tailwind CSS v4.
 
-First, run the development server:
+## Tech stack
+
+- **Framework** — Next.js 16 (App Router)
+- **Language** — TypeScript
+- **Styling** — Tailwind CSS v4 (CSS-first config)
+- **Content** — Markdown files with gray-matter + unified/rehype pipeline
+- **Email** — Resend
+- **Deployment** — Netlify (`@netlify/plugin-nextjs`)
+
+## Local setup
+
+**Prerequisites:** Node.js ≥ 22, npm
 
 ```bash
+# Install dependencies
+npm install
+
+# Start dev server
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Environment variables
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Create a `.env.local` file at the project root:
 
-## Learn More
+```env
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+RESEND_API_KEY=re_...
+CONTACT_TO_EMAIL=your@email.com
+```
 
-To learn more about Next.js, take a look at the following resources:
+| Variable               | Required | Description                                                             |
+| ---------------------- | -------- | ----------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SITE_URL` | Yes      | Canonical base URL (used in sitemap and OG images)                      |
+| `RESEND_API_KEY`       | Yes      | API key from [resend.com](https://resend.com) — powers the contact form |
+| `CONTACT_TO_EMAIL`     | Yes      | Email address that receives contact form submissions                    |
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Folder structure
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+```
+src/
+├── app/                     # Next.js App Router pages and layouts
+│   ├── layout.tsx           # Root layout (fonts, metadata defaults, dark-mode)
+│   ├── page.tsx             # Homepage (Hero + LatestPosts + FeaturedProjects + CTA)
+│   ├── about/page.tsx       # About page (bio, skills, experience timeline)
+│   ├── blog/
+│   │   ├── page.tsx         # Blog listing
+│   │   └── [slug]/page.tsx  # Individual post (rendered via unified pipeline)
+│   ├── projects/
+│   │   ├── page.tsx         # Projects listing
+│   │   └── [slug]/page.tsx  # Project detail
+│   ├── contact/page.tsx     # Contact form
+│   ├── api/contact/route.ts # POST handler — sends email via Resend
+│   ├── opengraph-image.tsx  # Default OG image (edge runtime)
+│   ├── sitemap.ts           # Dynamic sitemap
+│   └── robots.ts            # robots.txt
+├── components/              # React components, co-located by feature
+├── data/projects.ts         # Static project data
+├── lib/posts.ts             # Markdown parsing utilities
+└── types/                   # Shared TypeScript types
+posts/                       # Blog post Markdown files
+```
 
-## Deploy on Vercel
+## How to add a blog post
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+1. Create a new file in `posts/` using kebab-case: `posts/my-new-post.md`
+2. Add the required frontmatter:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```markdown
+---
+title: My New Post
+date: '2026-05-01'
+summary: A one-sentence description shown in the post card and meta tags.
+tags:
+  - Tag One
+  - Tag Two
+---
+
+Your post content here. Markdown and fenced code blocks are fully supported.
+```
+
+3. The post is statically generated at `/blog/my-new-post` on the next build. No other files need to be touched.
+
+**Frontmatter fields:**
+
+| Field     | Required | Description                                   |
+| --------- | -------- | --------------------------------------------- |
+| `title`   | Yes      | Post title                                    |
+| `date`    | Yes      | ISO date string (`YYYY-MM-DD`)                |
+| `summary` | Yes      | Short description (used in cards and OG meta) |
+| `tags`    | No       | Array of tag strings                          |
+
+## How to add a project
+
+Edit `src/data/projects.ts` and append an entry to the `projects` array:
+
+```ts
+{
+  slug: 'my-project',           // URL: /projects/my-project
+  title: 'My Project',
+  description: 'Short description shown in the card.',
+  longDescription: 'Optional longer description for the detail page.',
+  tags: ['React', 'TypeScript'],
+  githubUrl: 'https://github.com/...',
+  liveUrl: 'https://...',
+  featured: true,               // Show on homepage FeaturedProjects section
+}
+```
+
+## Scripts
+
+| Command         | Description                  |
+| --------------- | ---------------------------- |
+| `npm run dev`   | Start development server     |
+| `npm run build` | Production build             |
+| `npm start`     | Run production build locally |
+| `npm run lint`  | Run ESLint                   |
+
+## Deployment
+
+The site deploys automatically to Netlify via GitHub Actions.
+
+- **Production** — merges to `main` trigger a production deploy
+- **Previews** — pull requests get a preview URL posted as a PR comment
+
+### Manual deploy
+
+```bash
+# Requires Netlify CLI and the env vars below set
+npm run build
+npx netlify deploy --build --prod
+```
+
+### Required GitHub secrets
+
+| Secret                 | Description                                  |
+| ---------------------- | -------------------------------------------- |
+| `NETLIFY_AUTH_TOKEN`   | Personal access token from Netlify           |
+| `NETLIFY_SITE_ID`      | Site API ID from Netlify site settings       |
+| `RESEND_API_KEY`       | Resend API key                               |
+| `CONTACT_TO_EMAIL`     | Email address for contact form delivery      |
+| `NEXT_PUBLIC_SITE_URL` | Production URL (e.g. `https://espython.dev`) |

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,20 @@
       "name": "portfolio-blog",
       "version": "0.1.0",
       "dependencies": {
+        "gray-matter": "^4.0.3",
         "next": "16.2.2",
         "next-themes": "^0.4.6",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "rehype-pretty-code": "^0.14.3",
+        "remark": "^15.0.1",
+        "remark-html": "^16.0.1"
       },
       "devDependencies": {
         "@netlify/plugin-nextjs": "^5.15.9",
         "@tailwindcss/postcss": "^4",
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1249,6 +1255,114 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1540,12 +1654,30 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1559,6 +1691,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1590,6 +1737,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -1885,6 +2038,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -2470,6 +2629,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2627,6 +2796,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2642,6 +2821,36 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/cli-cursor": {
@@ -2709,6 +2918,16 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -2821,7 +3040,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2833,6 +3051,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -2878,6 +3109,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2886,6 +3126,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/doctrine": {
@@ -2942,6 +3195,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -3518,6 +3783,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3570,6 +3848,24 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3919,6 +4215,43 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -4013,6 +4346,138 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4028,6 +4493,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/husky": {
@@ -4256,6 +4731,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4382,6 +4866,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -4662,6 +5158,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -5087,6 +5592,16 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5130,6 +5645,99 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5139,6 +5747,448 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5194,7 +6244,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5494,6 +6543,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
+      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5573,6 +6641,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-numeric-range": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+      "license": "ISC"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -5698,6 +6784,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5780,6 +6876,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -5799,6 +6922,105 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-pretty-code": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/rehype-pretty-code/-/rehype-pretty-code-0.14.3.tgz",
+      "integrity": "sha512-Cz692FeYusTjT5cfFWLc4r7JhgC3/JlJptgUh4iffBxWxUnWW1oqbWFi7jGCeq00DYUm8yzoTnvpocaYa5x82g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.0",
+        "parse-numeric-range": "^1.3.0",
+        "rehype-parse": "^9.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "shiki": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/remark": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
+      "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-html": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-16.0.1.tgz",
+      "integrity": "sha512-B9JqA5i0qZe0Nsf49q3OXyGvyXuZFDzAP2iOFLEumymuYJITVpiH1IgsTEwTpdptDmZlMDMWeDmSawdaJIGCXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "hast-util-sanitize": "^5.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -5965,6 +7187,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -6105,6 +7340,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -6232,6 +7487,22 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -6394,6 +7665,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -6418,6 +7703,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -6572,6 +7866,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6774,6 +8088,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -6848,6 +8249,58 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {
@@ -7078,6 +8531,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,12 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "rehype-pretty-code": "^0.14.3",
+        "rehype-stringify": "^10.0.1",
         "remark": "^15.0.1",
-        "remark-html": "^16.0.1"
+        "remark-html": "^16.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "unified": "^11.0.5"
       },
       "devDependencies": {
         "@netlify/plugin-nextjs": "^5.15.9",
@@ -6997,6 +7001,21 @@
         "shiki": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
@@ -7040,6 +7059,23 @@
         "mdast-util-from-markdown": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfolio-blog",
       "version": "0.1.0",
       "dependencies": {
+        "@tailwindcss/typography": "^0.5.19",
         "gray-matter": "^4.0.3",
         "next": "16.2.2",
         "next-themes": "^0.4.6",
@@ -1643,6 +1644,18 @@
         "tailwindcss": "4.2.2"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2966,6 +2979,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -6746,6 +6771,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7780,7 +7818,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -8250,6 +8287,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "remark-html": "^16.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
+        "resend": "^6.10.0",
         "unified": "^11.0.5"
       },
       "devDependencies": {
@@ -1367,6 +1368,12 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -3946,6 +3953,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -6746,6 +6759,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -7095,6 +7114,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.10.0.tgz",
+      "integrity": "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.88.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -7585,6 +7625,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -7848,6 +7898,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.88.0.tgz",
+      "integrity": "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tailwindcss": {
@@ -8329,6 +8389,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "19.2.4"
       },
       "devDependencies": {
+        "@netlify/plugin-nextjs": "^5.15.9",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1037,6 +1038,16 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@netlify/plugin-nextjs": {
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.15.9.tgz",
+      "integrity": "sha512-4kJvV+wrt4/ncehfaOXfhv1FYKCv9EFjq6/tgXXYSlqPDcbsuTXR0DTz9IvyZ/CpPRadRD/zzIqD9wXgCmA2lg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "gray-matter": "^4.0.3",
     "next": "16.2.2",
     "next-themes": "^0.4.6",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "rehype-pretty-code": "^0.14.3",
+    "remark": "^15.0.1",
+    "remark-html": "^16.0.1"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -25,6 +29,8 @@
   "devDependencies": {
     "@netlify/plugin-nextjs": "^5.15.9",
     "@tailwindcss/postcss": "^4",
+    "@types/hast": "^3.0.4",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "*.{js,mjs,json,css,md}": "prettier --write"
   },
   "devDependencies": {
+    "@netlify/plugin-nextjs": "^5.15.9",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "remark-html": "^16.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
+    "resend": "^6.10.0",
     "unified": "^11.0.5"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "gray-matter": "^4.0.3",
     "next": "16.2.2",
     "next-themes": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,12 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "rehype-pretty-code": "^0.14.3",
+    "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",
-    "remark-html": "^16.0.1"
+    "remark-html": "^16.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "unified": "^11.0.5"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/posts/getting-started-with-nextjs-15.md
+++ b/posts/getting-started-with-nextjs-15.md
@@ -1,0 +1,51 @@
+---
+title: Getting Started with Next.js 15
+date: '2026-03-20'
+summary: A deep dive into what changed in Next.js 15 — new APIs, breaking changes, and how to migrate your existing app.
+tags:
+  - Next.js
+  - React
+---
+
+Next.js 15 ships with a set of breaking changes that are easy to miss if you're upgrading from v14. This post covers what changed, what to watch out for, and how to make your migration smooth.
+
+## What's New
+
+### `params` is Now a Promise
+
+The most impactful change for App Router users: `params` and `searchParams` are now asynchronous. You must `await` them before accessing values.
+
+```tsx
+// Before (Next.js 14)
+export default function Page({ params }: { params: { slug: string } }) {
+  return <h1>{params.slug}</h1>
+}
+
+// After (Next.js 15)
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  return <h1>{slug}</h1>
+}
+```
+
+### Turbopack is Now Stable for `next dev`
+
+Turbopack graduates from beta. You get significantly faster HMR out of the box — no config needed.
+
+### `fetch` Caching Defaults Changed
+
+Fetch requests are **no longer cached by default**. To cache, you must explicitly opt in:
+
+```ts
+const data = await fetch('/api/data', { cache: 'force-cache' })
+```
+
+## Migration Checklist
+
+- Update all `params` and `searchParams` accesses to use `await`
+- Review any `fetch` calls that relied on default caching
+- Run `next lint` — the new ESLint rules will catch most issues
+
+## Conclusion
+
+Next.js 15 is a worthwhile upgrade. The async params change feels jarring at first, but it enables better streaming and caching primitives down the line.

--- a/posts/mastering-tailwind-css-v4.md
+++ b/posts/mastering-tailwind-css-v4.md
@@ -1,0 +1,51 @@
+---
+title: Mastering Tailwind CSS v4
+date: '2026-03-10'
+summary: Tailwind v4 rewrites the engine from scratch. Here is what the new CSS-first config means for your workflow.
+tags:
+  - CSS
+  - Tailwind
+---
+
+Tailwind CSS v4 is a ground-up rewrite. The JavaScript config file is gone — configuration now lives in CSS using `@theme`. This post walks through the key changes and how to adapt your workflow.
+
+## The New CSS-First Config
+
+Instead of `tailwind.config.js`, you configure Tailwind inside your CSS file:
+
+```css
+@import 'tailwindcss';
+
+@theme {
+  --color-primary: #6366f1;
+  --font-sans: 'Inter', ui-sans-serif;
+  --spacing-18: 4.5rem;
+}
+```
+
+Every `--variable` you define under `@theme` automatically becomes a utility class. `--color-primary` generates `bg-primary`, `text-primary`, `border-primary`, and so on.
+
+## Design Tokens as CSS Variables
+
+Your theme values are now real CSS custom properties on `:root`. That means you can read them in JavaScript, use them in `style` props, and override them per-component with a wrapping selector — no Tailwind plugins needed.
+
+```tsx
+<div style={{ color: 'var(--color-primary)' }}>Hello</div>
+```
+
+## What Stayed the Same
+
+- All the utility classes you know work exactly the same
+- `@apply` still works
+- The JIT engine is still there (faster than ever)
+
+## Migration Tips
+
+1. Delete `tailwind.config.js` and `postcss.config.js`
+2. Move theme values into `@theme {}` in your CSS
+3. Replace `theme('colors.primary')` in CSS with `var(--color-primary)`
+4. Run `npx tailwindcss upgrade` to auto-migrate most of the syntax
+
+## Conclusion
+
+The CSS-first approach aligns Tailwind with the direction the web platform is heading. Once you internalize that your theme _is_ CSS variables, v4 feels like a natural evolution.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -38,21 +38,24 @@ function HeroBio() {
             About Me
           </p>
           <h1 className="mb-4 text-4xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-5xl">
-            Hi, I&apos;m <span className="text-[var(--color-primary)]">YourName</span>
+            Hi, I&apos;m <span className="text-[var(--color-primary)]">Eslam</span>
           </h1>
           <div className="space-y-4 text-lg leading-relaxed text-[var(--color-text-muted)]">
             <p>
-              I&apos;m a full-stack developer based in —, passionate about building fast, accessible
-              web experiences. I work primarily with TypeScript, React, and Node.js, and I care
-              deeply about clean code and great developer experience.
+              I&apos;m a Senior Full Stack Engineer based in Luxor, Egypt, with 6+ years of
+              experience building scalable web and mobile applications. I work primarily with
+              TypeScript, React, Node.js, and AWS — and I care deeply about clean architecture,
+              performance, and great developer experience.
             </p>
             <p>
-              When I&apos;m not coding, you&apos;ll find me writing about things I&apos;ve learned,
-              contributing to open source, or exploring new tools that make development more
-              enjoyable.
+              Currently at VOIS (Vodafone Intelligent Solutions), where I work on large-scale web
+              products. Previously I&apos;ve built platforms at InVitro Capital, Swenson He,
+              DotOffice, HyperList, and ADRI — shipping everything from real estate marketplaces and
+              SaaS dashboards to open-source developer tooling.
             </p>
             <p>
-              I&apos;m currently open to new opportunities — feel free to{' '}
+              Outside of work I write about things I&apos;ve learned, contribute to open source, and
+              explore new tools that make development more enjoyable. Feel free to{' '}
               <a
                 href="/contact"
                 className="font-medium text-[var(--color-primary)] underline underline-offset-4 transition-colors hover:text-[var(--color-primary-hover)]"
@@ -74,7 +77,7 @@ function HeroBio() {
               GitHub
             </a>
             <a
-              href="https://linkedin.com/in/yourname"
+              href="https://www.linkedin.com/in/eslam-mahmoud-a63b06116/"
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-lg border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-text)] transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]"

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -18,6 +18,7 @@ export default function AboutPage() {
   return (
     <main>
       <HeroBio />
+      <Skills />
       <ExperienceTimeline />
     </main>
   )
@@ -93,6 +94,94 @@ function HeroBio() {
               Download CV
             </a>
           </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+const SKILL_GROUPS = [
+  {
+    label: 'Frontend',
+    skills: [
+      'TypeScript',
+      'JavaScript',
+      'React.js',
+      'Next.js',
+      'React Native',
+      'Redux',
+      'TailwindCSS',
+      'Material-UI',
+      'HTML & CSS',
+    ],
+  },
+  {
+    label: 'Backend',
+    skills: [
+      'Node.js',
+      'Express.js',
+      'Nest.js',
+      'Java',
+      'Spring / Quarkus',
+      'C# / ASP.NET',
+      'Python',
+      'GraphQL',
+    ],
+  },
+  {
+    label: 'Cloud & DevOps',
+    skills: [
+      'AWS (Lambda, EC2, S3, RDS, CloudFront, ECS, SES…)',
+      'Azure',
+      'Google Cloud Platform',
+      'GitHub Actions',
+      'CloudFormation',
+      'CI/CD',
+    ],
+  },
+  {
+    label: 'Databases',
+    skills: ['PostgreSQL', 'MongoDB', 'MSSQL', 'DynamoDB'],
+  },
+  {
+    label: 'Testing & Performance',
+    skills: ['Jest', 'Mocha', 'Code Splitting', 'Lazy Loading', 'Memoization'],
+  },
+  {
+    label: 'Security & Auth',
+    skills: ['JWT', 'OAuth', 'AWS IAM', 'Azure Active Directory'],
+  },
+]
+
+function Skills() {
+  return (
+    <section className="bg-[var(--color-bg-subtle)]">
+      <div className="mx-auto max-w-4xl px-6 py-20">
+        <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+          Tech Stack
+        </p>
+        <h2 className="mb-10 text-3xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-4xl">
+          Skills &amp; Technologies
+        </h2>
+
+        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {SKILL_GROUPS.map((group) => (
+            <div key={group.label}>
+              <h3 className="mb-3 text-xs font-semibold tracking-widest text-[var(--color-primary)] uppercase">
+                {group.label}
+              </h3>
+              <ul className="flex flex-wrap gap-2">
+                {group.skills.map((skill) => (
+                  <li
+                    key={skill}
+                    className="rounded-md bg-[var(--color-surface)] px-3 py-1.5 text-sm font-medium text-[var(--color-text-muted)] ring-1 ring-[var(--color-border)]"
+                  >
+                    {skill}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,6 +6,12 @@ export const metadata: Metadata = {
   title: 'About',
   description:
     'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications.',
+  openGraph: {
+    url: '/about',
+    title: 'About — Eslam Mahmoud',
+    description:
+      'Full Stack Software Engineer with 6+ years of experience. Currently Senior Engineer at VOIS (Vodafone Intelligent Solutions).',
+  },
 }
 
 export default function AboutPage() {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,87 @@
+import { type Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'About',
+  description: 'Learn more about who I am, what I do, and the tools I work with.',
+}
+
+export default function AboutPage() {
+  return (
+    <main>
+      <HeroBio />
+    </main>
+  )
+}
+
+function HeroBio() {
+  return (
+    <section className="mx-auto max-w-4xl px-6 py-20">
+      <div className="flex flex-col gap-12 md:flex-row md:items-start md:gap-16">
+        {/* Avatar placeholder */}
+        <div className="shrink-0">
+          <div className="h-36 w-36 rounded-2xl bg-[var(--color-bg-subtle)] ring-4 ring-[var(--color-border)] md:h-44 md:w-44" />
+        </div>
+
+        {/* Bio */}
+        <div className="flex-1">
+          <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+            About Me
+          </p>
+          <h1 className="mb-4 text-4xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-5xl">
+            Hi, I&apos;m <span className="text-[var(--color-primary)]">YourName</span>
+          </h1>
+          <div className="space-y-4 text-lg leading-relaxed text-[var(--color-text-muted)]">
+            <p>
+              I&apos;m a full-stack developer based in —, passionate about building fast, accessible
+              web experiences. I work primarily with TypeScript, React, and Node.js, and I care
+              deeply about clean code and great developer experience.
+            </p>
+            <p>
+              When I&apos;m not coding, you&apos;ll find me writing about things I&apos;ve learned,
+              contributing to open source, or exploring new tools that make development more
+              enjoyable.
+            </p>
+            <p>
+              I&apos;m currently open to new opportunities — feel free to{' '}
+              <a
+                href="/contact"
+                className="font-medium text-[var(--color-primary)] underline underline-offset-4 transition-colors hover:text-[var(--color-primary-hover)]"
+              >
+                get in touch
+              </a>
+              .
+            </p>
+          </div>
+
+          {/* Social links */}
+          <div className="mt-8 flex flex-wrap gap-4">
+            <a
+              href="https://github.com/espython"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-text)] transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]"
+            >
+              GitHub
+            </a>
+            <a
+              href="https://linkedin.com/in/yourname"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg border border-[var(--color-border)] px-4 py-2 text-sm font-medium text-[var(--color-text)] transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]"
+            >
+              LinkedIn
+            </a>
+            <a
+              href="/resume.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[var(--color-primary-hover)]"
+            >
+              Download CV
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,14 +1,18 @@
 import { type Metadata } from 'next'
 
+import { ExperienceTimeline } from '@/components/about/ExperienceTimeline'
+
 export const metadata: Metadata = {
   title: 'About',
-  description: 'Learn more about who I am, what I do, and the tools I work with.',
+  description:
+    'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications.',
 }
 
 export default function AboutPage() {
   return (
     <main>
       <HeroBio />
+      <ExperienceTimeline />
     </main>
   )
 }

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,32 @@
+import { Resend } from 'resend'
+
+const TO_EMAIL = 'espython85@gmail.com'
+
+export async function POST(request: Request) {
+  const resend = new Resend(process.env.RESEND_API_KEY)
+  const { name, email, subject, message } = await request.json()
+
+  if (!name || !email || !subject || !message) {
+    return Response.json({ error: 'All fields are required.' }, { status: 400 })
+  }
+
+  const { error } = await resend.emails.send({
+    from: 'Portfolio Contact <onboarding@resend.dev>',
+    to: TO_EMAIL,
+    replyTo: email,
+    subject: `[Portfolio] ${subject}`,
+    text: `From: ${name} <${email}>\n\n${message}`,
+    html: `
+      <p><strong>From:</strong> ${name} &lt;${email}&gt;</p>
+      <p><strong>Subject:</strong> ${subject}</p>
+      <hr />
+      <p>${message.replace(/\n/g, '<br />')}</p>
+    `,
+  })
+
+  if (error) {
+    return Response.json({ error: 'Failed to send message.' }, { status: 500 })
+  }
+
+  return Response.json({ success: true })
+}

--- a/src/app/blog/[slug]/opengraph-image.tsx
+++ b/src/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,103 @@
+import { ImageResponse } from 'next/og'
+
+import { getPostBySlug } from '@/lib/posts'
+
+export const runtime = 'nodejs'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function BlogPostOGImage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const post = await getPostBySlug(slug)
+
+  const title = post?.title ?? 'Blog Post'
+  const summary = post?.summary ?? ''
+  const tags = post?.tags ?? []
+  const date = post?.date
+    ? new Date(post.date).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : ''
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '72px 80px',
+        background: 'linear-gradient(135deg, #0a0a0f 0%, #1c1c27 100%)',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      {/* Top — site label */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            background: '#6366f1',
+          }}
+        />
+        <span style={{ fontSize: 18, color: '#6366f1', fontWeight: 600 }}>
+          Eslam Mahmoud · Blog
+        </span>
+      </div>
+
+      {/* Middle — title + summary */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <div
+          style={{
+            fontSize: 56,
+            fontWeight: 800,
+            color: '#f0f0f8',
+            lineHeight: 1.15,
+            maxWidth: 900,
+          }}
+        >
+          {title}
+        </div>
+        {summary && (
+          <div
+            style={{
+              fontSize: 22,
+              color: '#9898b3',
+              lineHeight: 1.5,
+              maxWidth: 800,
+            }}
+          >
+            {summary}
+          </div>
+        )}
+      </div>
+
+      {/* Bottom — tags + date */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', gap: 10 }}>
+          {tags.slice(0, 3).map((tag) => (
+            <div
+              key={tag}
+              style={{
+                padding: '6px 14px',
+                borderRadius: 6,
+                background: '#2e2e3e',
+                color: '#9898b3',
+                fontSize: 16,
+                fontWeight: 500,
+              }}
+            >
+              {tag}
+            </div>
+          ))}
+        </div>
+        {date && <div style={{ fontSize: 18, color: '#52526e' }}>{date}</div>}
+      </div>
+    </div>,
+    { ...size }
+  )
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -61,9 +61,11 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
         <h1 className="text-4xl font-extrabold leading-tight tracking-tight text-[var(--color-text)] sm:text-5xl">
           {post.title}
         </h1>
-        <time dateTime={post.date} className="mt-4 block text-sm text-[var(--color-text-subtle)]">
-          {formatDate(post.date)}
-        </time>
+        <div className="mt-4 flex items-center gap-2 text-sm text-[var(--color-text-subtle)]">
+          <time dateTime={post.date}>{formatDate(post.date)}</time>
+          <span>·</span>
+          <span>{post.readingTime} min read</span>
+        </div>
         <p className="mt-4 text-lg text-[var(--color-text-muted)]">{post.summary}</p>
       </header>
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { type Metadata } from 'next'
 
-import { getAllPostSlugs, getPostBySlug } from '@/lib/posts'
+import { getAllPostSlugs, getAdjacentPosts, getPostBySlug } from '@/lib/posts'
 
 export function generateStaticParams() {
   return getAllPostSlugs().map((slug) => ({ slug }))
@@ -35,6 +35,8 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
   const post = await getPostBySlug(slug)
 
   if (!post) notFound()
+
+  const { prev, next } = getAdjacentPosts(slug)
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-20">
@@ -69,6 +71,29 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
         className="prose prose-neutral max-w-none dark:prose-invert"
         dangerouslySetInnerHTML={{ __html: post.contentHtml }}
       />
+
+      <nav className="mt-16 flex items-center justify-between gap-4 border-t border-[var(--color-border)] pt-8">
+        <div className="flex-1">
+          {prev && (
+            <Link href={`/blog/${prev.slug}`} className="group flex flex-col gap-1 text-sm">
+              <span className="text-[var(--color-text-subtle)]">← Previous</span>
+              <span className="font-medium text-[var(--color-text)] transition-colors group-hover:text-[var(--color-primary)]">
+                {prev.title}
+              </span>
+            </Link>
+          )}
+        </div>
+        <div className="flex-1 text-right">
+          {next && (
+            <Link href={`/blog/${next.slug}`} className="group flex flex-col gap-1 text-sm">
+              <span className="text-[var(--color-text-subtle)]">Next →</span>
+              <span className="font-medium text-[var(--color-text)] transition-colors group-hover:text-[var(--color-primary)]">
+                {next.title}
+              </span>
+            </Link>
+          )}
+        </div>
+      </nav>
     </main>
   )
 }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,74 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { type Metadata } from 'next'
+
+import { getAllPostSlugs, getPostBySlug } from '@/lib/posts'
+
+export function generateStaticParams() {
+  return getAllPostSlugs().map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  const post = await getPostBySlug(slug)
+  if (!post) return {}
+  return {
+    title: post.title,
+    description: post.summary,
+  }
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export default async function BlogPostPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const post = await getPostBySlug(slug)
+
+  if (!post) notFound()
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-20">
+      <Link
+        href="/blog"
+        className="mb-8 inline-flex items-center gap-1 text-sm text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
+      >
+        ← All Posts
+      </Link>
+
+      <header className="mt-4 mb-10">
+        <div className="mb-4 flex flex-wrap gap-2">
+          {post.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-md bg-[var(--color-bg-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-muted)]"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+        <h1 className="text-4xl font-extrabold leading-tight tracking-tight text-[var(--color-text)] sm:text-5xl">
+          {post.title}
+        </h1>
+        <time dateTime={post.date} className="mt-4 block text-sm text-[var(--color-text-subtle)]">
+          {formatDate(post.date)}
+        </time>
+        <p className="mt-4 text-lg text-[var(--color-text-muted)]">{post.summary}</p>
+      </header>
+
+      <article
+        className="prose prose-neutral max-w-none dark:prose-invert"
+        dangerouslySetInnerHTML={{ __html: post.contentHtml }}
+      />
+    </main>
+  )
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -19,6 +19,15 @@ export async function generateMetadata({
   return {
     title: post.title,
     description: post.summary,
+    openGraph: {
+      url: `/blog/${slug}`,
+      title: post.title,
+      description: post.summary,
+      type: 'article',
+      publishedTime: post.date,
+      tags: post.tags,
+    },
+    twitter: { card: 'summary_large_image', title: post.title, description: post.summary },
   }
 }
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,41 @@
+import { type Metadata } from 'next'
+
+import { BlogPostCard } from '@/components/blog/BlogPostCard'
+import { getAllPostsMeta } from '@/lib/posts'
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: 'Thoughts on web development, TypeScript, and building things.',
+}
+
+export default function BlogPage() {
+  const posts = getAllPostsMeta()
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-20">
+      <div className="mb-12">
+        <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+          Writing
+        </p>
+        <h1 className="text-4xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-5xl">
+          Blog
+        </h1>
+        <p className="mt-4 max-w-2xl text-lg text-[var(--color-text-muted)]">
+          Thoughts on web development, TypeScript, and things I learn along the way.
+        </p>
+      </div>
+
+      {posts.length === 0 ? (
+        <p className="text-[var(--color-text-muted)]">No posts yet. Check back soon.</p>
+      ) : (
+        <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {posts.map((post) => (
+            <li key={post.slug}>
+              <BlogPostCard post={post} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -6,6 +6,12 @@ import { getAllPostsMeta } from '@/lib/posts'
 export const metadata: Metadata = {
   title: 'Blog',
   description: 'Thoughts on web development, TypeScript, and building things.',
+  openGraph: {
+    url: '/blog',
+    title: 'Blog — Eslam Mahmoud',
+    description:
+      'Thoughts on web development, TypeScript, React, and things I learn along the way.',
+  },
 }
 
 export default function BlogPage() {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,6 +5,12 @@ import { ContactForm } from '@/components/contact/ContactForm'
 export const metadata: Metadata = {
   title: 'Contact',
   description: 'Get in touch with Eslam Mahmoud — open to new opportunities and collaborations.',
+  openGraph: {
+    url: '/contact',
+    title: 'Contact — Eslam Mahmoud',
+    description:
+      'Get in touch — open to new opportunities, collaborations, or a friendly chat about tech.',
+  },
 }
 
 export default function ContactPage() {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,67 @@
+import { type Metadata } from 'next'
+
+import { ContactForm } from '@/components/contact/ContactForm'
+
+export const metadata: Metadata = {
+  title: 'Contact',
+  description: 'Get in touch with Eslam Mahmoud — open to new opportunities and collaborations.',
+}
+
+export default function ContactPage() {
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-20">
+      <div className="grid gap-16 md:grid-cols-2">
+        {/* Left — copy */}
+        <div>
+          <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+            Say Hello
+          </p>
+          <h1 className="mb-4 text-4xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-5xl">
+            Get in Touch
+          </h1>
+          <p className="mb-8 text-lg leading-relaxed text-[var(--color-text-muted)]">
+            I&apos;m open to new opportunities, collaborations, or just a friendly chat about tech.
+            Fill in the form and I&apos;ll get back to you as soon as possible.
+          </p>
+
+          <ul className="space-y-4 text-sm">
+            <li className="flex items-center gap-3 text-[var(--color-text-muted)]">
+              <span className="font-medium text-[var(--color-text)]">Email</span>
+              <a
+                href="mailto:espython85@gmail.com"
+                className="transition-colors hover:text-[var(--color-primary)]"
+              >
+                espython85@gmail.com
+              </a>
+            </li>
+            <li className="flex items-center gap-3 text-[var(--color-text-muted)]">
+              <span className="font-medium text-[var(--color-text)]">LinkedIn</span>
+              <a
+                href="https://linkedin.com/in/eslam-mahmoud-a63b06116"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="transition-colors hover:text-[var(--color-primary)]"
+              >
+                eslam-mahmoud-a63b06116
+              </a>
+            </li>
+            <li className="flex items-center gap-3 text-[var(--color-text-muted)]">
+              <span className="font-medium text-[var(--color-text)]">GitHub</span>
+              <a
+                href="https://github.com/espython"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="transition-colors hover:text-[var(--color-primary)]"
+              >
+                github.com/espython
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        {/* Right — form */}
+        <ContactForm />
+      </div>
+    </main>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,6 +43,22 @@
   --color-text-subtle: var(--color-text-subtle);
 }
 
+/* ── Syntax highlighting (rehype-pretty-code) ───────────────── */
+[data-rehype-pretty-code-figure] pre {
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.75rem;
+  overflow-x: auto;
+  font-size: 0.875rem;
+  line-height: 1.7;
+  border: 1px solid var(--color-border);
+}
+
+[data-rehype-pretty-code-figure] code {
+  background: none;
+  padding: 0;
+  font-size: inherit;
+}
+
 /* ── Base ───────────────────────────────────────────────────── */
 html {
   scroll-behavior: smooth;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@plugin '@tailwindcss/typography';
 
 /* ── Design tokens ─────────────────────────────────────────── */
 :root {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,7 +28,7 @@
 
   --color-text: #f0f0f8;
   --color-text-muted: #9898b3;
-  --color-text-subtle: #52526e;
+  --color-text-subtle: #7878a0;
 }
 
 @theme inline {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
 import { ThemeProvider } from 'next-themes'
 
@@ -14,6 +14,15 @@ const inter = Inter({
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://espython.dev'
 const SITE_NAME = 'Eslam Mahmoud'
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#fafaff' },
+    { media: '(prefers-color-scheme: dark)', color: '#0a0a0f' },
+  ],
+}
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,12 +12,35 @@ const inter = Inter({
   display: 'swap',
 })
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://espython.dev'
+const SITE_NAME = 'Eslam Mahmoud'
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: 'YourName.dev',
-    template: '%s | YourName.dev',
+    default: `${SITE_NAME} — Full Stack Engineer`,
+    template: `%s | ${SITE_NAME}`,
   },
-  description: 'Full-stack developer portfolio and blog.',
+  description:
+    'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications with React, Node.js, and AWS.',
+  authors: [{ name: SITE_NAME }],
+  keywords: ['Full Stack Engineer', 'React', 'TypeScript', 'Node.js', 'AWS', 'Next.js'],
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    locale: 'en_US',
+    url: SITE_URL,
+    title: `${SITE_NAME} — Full Stack Engineer`,
+    description:
+      'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${SITE_NAME} — Full Stack Engineer`,
+    description:
+      'Full Stack Software Engineer with 6+ years of experience building scalable web and mobile applications.',
+  },
+  robots: { index: true, follow: true },
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,85 @@
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'Eslam Mahmoud — Full Stack Engineer'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function OGImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        padding: '80px',
+        background: 'linear-gradient(135deg, #0a0a0f 0%, #1c1c27 100%)',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      {/* Accent bar */}
+      <div
+        style={{
+          width: 64,
+          height: 6,
+          borderRadius: 3,
+          background: '#6366f1',
+          marginBottom: 40,
+        }}
+      />
+
+      {/* Name */}
+      <div
+        style={{
+          fontSize: 64,
+          fontWeight: 800,
+          color: '#f0f0f8',
+          lineHeight: 1.1,
+          marginBottom: 16,
+        }}
+      >
+        Eslam Mahmoud
+      </div>
+
+      {/* Title */}
+      <div
+        style={{
+          fontSize: 32,
+          fontWeight: 500,
+          color: '#6366f1',
+          marginBottom: 24,
+        }}
+      >
+        Full Stack Software Engineer
+      </div>
+
+      {/* Description */}
+      <div
+        style={{
+          fontSize: 20,
+          color: '#9898b3',
+          lineHeight: 1.5,
+          maxWidth: 700,
+        }}
+      >
+        React · Node.js · TypeScript · AWS · 6+ years of experience
+      </div>
+
+      {/* URL */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 60,
+          right: 80,
+          fontSize: 18,
+          color: '#52526e',
+        }}
+      >
+        espython.dev
+      </div>
+    </div>,
+    { ...size }
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 import { Hero } from '@/components/home/Hero'
 import { FeaturedProjects } from '@/components/home/FeaturedProjects'
+import { LatestPosts } from '@/components/home/LatestPosts'
 
 export default function Home() {
   return (
     <main>
       <Hero />
       <FeaturedProjects />
+      <LatestPosts />
     </main>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,15 @@
+import { type Metadata } from 'next'
+
 import { Hero } from '@/components/home/Hero'
+
+export const metadata: Metadata = {
+  openGraph: {
+    url: '/',
+    title: 'Eslam Mahmoud — Full Stack Engineer',
+    description:
+      'Portfolio and blog of Eslam Mahmoud — Full Stack Software Engineer specializing in React, Node.js, and AWS.',
+  },
+}
 import { FeaturedProjects } from '@/components/home/FeaturedProjects'
 import { LatestPosts } from '@/components/home/LatestPosts'
 import { CallToAction } from '@/components/home/CallToAction'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,17 @@
 import { Hero } from '@/components/home/Hero'
 import { FeaturedProjects } from '@/components/home/FeaturedProjects'
 import { LatestPosts } from '@/components/home/LatestPosts'
+import { CallToAction } from '@/components/home/CallToAction'
 
 export default function Home() {
   return (
     <main>
       <Hero />
-      <FeaturedProjects />
+      <section className="bg-[var(--color-bg-subtle)]">
+        <FeaturedProjects />
+      </section>
       <LatestPosts />
+      <CallToAction />
     </main>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
 import { Hero } from '@/components/home/Hero'
+import { FeaturedProjects } from '@/components/home/FeaturedProjects'
 
 export default function Home() {
   return (
     <main>
       <Hero />
+      <FeaturedProjects />
     </main>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,9 @@
+import { Hero } from '@/components/home/Hero'
+
 export default function Home() {
   return (
-    <div className="flex min-h-[60vh] items-center justify-center">
-      <p className="text-[var(--color-text-muted)]">Homepage coming soon — M3</p>
-    </div>
+    <main>
+      <Hero />
+    </main>
   )
 }

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -19,6 +19,16 @@ export async function generateMetadata({
   return {
     title: project.title,
     description: project.description,
+    openGraph: {
+      url: `/projects/${slug}`,
+      title: project.title,
+      description: project.description,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: project.title,
+      description: project.description,
+    },
   }
 }
 

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,83 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { type Metadata } from 'next'
+
+import { projects } from '@/data/projects'
+
+export function generateStaticParams() {
+  return projects.map((p) => ({ slug: p.slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  const project = projects.find((p) => p.slug === slug)
+  if (!project) return {}
+  return {
+    title: project.title,
+    description: project.description,
+  }
+}
+
+export default async function ProjectDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const project = projects.find((p) => p.slug === slug)
+
+  if (!project) notFound()
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-20">
+      <Link
+        href="/projects"
+        className="mb-8 inline-flex items-center gap-1 text-sm text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
+      >
+        ← All Projects
+      </Link>
+
+      <h1 className="mt-4 text-4xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-5xl">
+        {project.title}
+      </h1>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {project.tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-md bg-[var(--color-bg-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-muted)]"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      <p className="mt-8 text-lg leading-relaxed text-[var(--color-text-muted)]">
+        {project.longDescription ?? project.description}
+      </p>
+
+      <div className="mt-10 flex gap-4">
+        {project.githubUrl && (
+          <a
+            href={project.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg border border-[var(--color-border)] px-5 py-2.5 text-sm font-semibold text-[var(--color-text)] transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]"
+          >
+            View on GitHub
+          </a>
+        )}
+        {project.liveUrl && (
+          <a
+            href={project.liveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg bg-[var(--color-primary)] px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-primary-hover)]"
+          >
+            Live Demo
+          </a>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -6,6 +6,12 @@ import { projects } from '@/data/projects'
 export const metadata: Metadata = {
   title: 'Projects',
   description: 'A collection of projects I have built.',
+  openGraph: {
+    url: '/projects',
+    title: 'Projects — Eslam Mahmoud',
+    description:
+      'Full-stack and open-source projects built with React, Node.js, TypeScript, and AWS.',
+  },
 }
 
 export default function ProjectsPage() {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,35 @@
+import { type Metadata } from 'next'
+
+import { ProjectCard } from '@/components/projects/ProjectCard'
+import { projects } from '@/data/projects'
+
+export const metadata: Metadata = {
+  title: 'Projects',
+  description: 'A collection of projects I have built.',
+}
+
+export default function ProjectsPage() {
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-20">
+      <div className="mb-12">
+        <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+          My Work
+        </p>
+        <h1 className="text-4xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-5xl">
+          Projects
+        </h1>
+        <p className="mt-4 max-w-2xl text-lg text-[var(--color-text-muted)]">
+          Things I&apos;ve built — from side projects to open-source tools.
+        </p>
+      </div>
+
+      <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {projects.map((project) => (
+          <li key={project.slug}>
+            <ProjectCard project={project} />
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://espython.dev'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/'],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,59 @@
+import type { MetadataRoute } from 'next'
+
+import { getAllPostsMeta } from '@/lib/posts'
+import { projects } from '@/data/projects'
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://espython.dev'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const posts = getAllPostsMeta()
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/projects`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/blog`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/contact`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.5,
+    },
+  ]
+
+  const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${SITE_URL}/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+    changeFrequency: 'monthly',
+    priority: 0.7,
+  }))
+
+  const projectRoutes: MetadataRoute.Sitemap = projects.map((project) => ({
+    url: `${SITE_URL}/projects/${project.slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly',
+    priority: 0.6,
+  }))
+
+  return [...staticRoutes, ...postRoutes, ...projectRoutes]
+}

--- a/src/components/about/ExperienceTimeline.tsx
+++ b/src/components/about/ExperienceTimeline.tsx
@@ -1,0 +1,134 @@
+interface Role {
+  title: string
+  company: string
+  period: string
+  location: string
+  highlights: string[]
+  tags: string[]
+}
+
+const EXPERIENCE: Role[] = [
+  {
+    title: 'Senior Software Engineer',
+    company: 'VOIS (Vodafone Intelligent Solutions)',
+    period: 'Present',
+    location: 'Remote',
+    highlights: [
+      'Building scalable enterprise-grade applications in a cross-functional agile team.',
+      'Leading frontend architecture decisions and conducting code reviews.',
+    ],
+    tags: ['TypeScript', 'React.js', 'Node.js'],
+  },
+  {
+    title: 'Senior Frontend Engineer',
+    company: 'InVitro Capital',
+    period: 'Nov 2024 – Present',
+    location: 'Irvine, CA — Remote',
+    highlights: [
+      'Architected complex, performant React/TypeScript applications with advanced state management.',
+      'Designed scalable AWS microservices (Lambda, CloudFront, S3, RDS, ECS).',
+      'Improved performance monitoring via CloudWatch and enforced granular IAM access control.',
+    ],
+    tags: ['React.js', 'Next.js', 'TypeScript', 'AWS', 'Node.js'],
+  },
+  {
+    title: 'Senior Full Stack Engineer',
+    company: 'Swenson He LLC',
+    period: 'May 2023 – Jun 2024',
+    location: 'Los Angeles, CA — Remote',
+    highlights: [
+      'Reduced infrastructure costs by 40% via AWS Lambda serverless architecture.',
+      'Designed CI/CD pipelines with GitHub Actions integrated with AWS Elastic Beanstalk.',
+      'Built secure auth systems (JWT, OAuth) and robust notification pipelines (SNS, SES).',
+    ],
+    tags: ['Node.js', 'Nest.js', 'React.js', 'AWS', 'PostgreSQL'],
+  },
+  {
+    title: 'Full Stack Developer',
+    company: 'DotOffice VB',
+    period: 'Nov 2021 – May 2023',
+    location: 'Amsterdam, Netherlands — Remote',
+    highlights: [
+      'Built a cloud-based document management platform on Azure VMs with Azure Functions.',
+      'Implemented Azure Active Directory for authentication and Azure Blob Storage for assets.',
+      'Designed MSSQL schemas and applied React performance patterns (code splitting, memoization).',
+    ],
+    tags: ['TypeScript', 'React.js', 'C#', 'ASP.NET', 'Azure', 'MSSQL'],
+  },
+  {
+    title: 'Software Engineer',
+    company: 'HyperList LLC',
+    period: 'Jun 2019 – Nov 2021',
+    location: 'Riyadh, KSA — Remote',
+    highlights: [
+      'Built scalable e-learning platforms on Google Cloud Platform with microservices architecture.',
+      'Developed a cross-platform iOS app with React Native.',
+      'Reduced load times by 35% through debugging and performance optimisation.',
+    ],
+    tags: ['React.js', 'React Native', 'Node.js', 'GCP'],
+  },
+  {
+    title: 'Frontend Developer',
+    company: 'Arabic Digital Research Institute',
+    period: 'Apr 2018 – Jun 2019',
+    location: 'Manama, Bahrain — Remote',
+    highlights: [
+      'Contributed to an AI-driven research platform using React.js and Ember.js.',
+      'Conducted code reviews and developed unit tests for UI components.',
+    ],
+    tags: ['React.js', 'Ember.js', 'JavaScript'],
+  },
+]
+
+export function ExperienceTimeline() {
+  return (
+    <section className="mx-auto max-w-4xl px-6 py-20">
+      <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+        Career
+      </p>
+      <h2 className="mb-12 text-3xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-4xl">
+        Experience
+      </h2>
+
+      <ol className="relative border-l border-[var(--color-border)]">
+        {EXPERIENCE.map((role, i) => (
+          <li key={i} className="mb-12 ml-6 last:mb-0">
+            {/* Timeline dot */}
+            <span className="absolute -left-[9px] flex h-4 w-4 items-center justify-center rounded-full bg-[var(--color-primary)] ring-4 ring-[var(--color-bg)]" />
+
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-[var(--color-text)]">{role.title}</h3>
+                <p className="text-sm font-medium text-[var(--color-primary)]">{role.company}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-sm text-[var(--color-text-muted)]">{role.period}</p>
+                <p className="text-xs text-[var(--color-text-subtle)]">{role.location}</p>
+              </div>
+            </div>
+
+            <ul className="mt-3 space-y-1.5">
+              {role.highlights.map((point, j) => (
+                <li key={j} className="flex gap-2 text-sm text-[var(--color-text-muted)]">
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-primary)]" />
+                  {point}
+                </li>
+              ))}
+            </ul>
+
+            <div className="mt-3 flex flex-wrap gap-2">
+              {role.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-md bg-[var(--color-bg-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-muted)]"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}

--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+
+import { type PostMeta } from '@/types/post'
+
+interface BlogPostCardProps {
+  post: PostMeta
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export function BlogPostCard({ post }: BlogPostCardProps) {
+  return (
+    <article className="group flex flex-col rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 transition-shadow hover:shadow-md">
+      <Link href={`/blog/${post.slug}`} className="flex flex-1 flex-col">
+        <time
+          dateTime={post.date}
+          className="mb-2 text-xs font-medium text-[var(--color-text-subtle)]"
+        >
+          {formatDate(post.date)}
+        </time>
+        <h3 className="mb-2 text-lg font-semibold text-[var(--color-text)] transition-colors group-hover:text-[var(--color-primary)]">
+          {post.title}
+        </h3>
+        <p className="flex-1 text-sm leading-relaxed text-[var(--color-text-muted)]">
+          {post.summary}
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {post.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-md bg-[var(--color-bg-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-muted)]"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </Link>
+    </article>
+  )
+}

--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -18,12 +18,11 @@ export function BlogPostCard({ post }: BlogPostCardProps) {
   return (
     <article className="group flex flex-col rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 transition-shadow hover:shadow-md">
       <Link href={`/blog/${post.slug}`} className="flex flex-1 flex-col">
-        <time
-          dateTime={post.date}
-          className="mb-2 text-xs font-medium text-[var(--color-text-subtle)]"
-        >
-          {formatDate(post.date)}
-        </time>
+        <div className="mb-2 flex items-center gap-2 text-xs text-[var(--color-text-subtle)]">
+          <time dateTime={post.date}>{formatDate(post.date)}</time>
+          <span>·</span>
+          <span>{post.readingTime} min read</span>
+        </div>
         <h3 className="mb-2 text-lg font-semibold text-[var(--color-text)] transition-colors group-hover:text-[var(--color-primary)]">
           {post.title}
         </h3>

--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -23,9 +23,9 @@ export function BlogPostCard({ post }: BlogPostCardProps) {
           <span>·</span>
           <span>{post.readingTime} min read</span>
         </div>
-        <h3 className="mb-2 text-lg font-semibold text-[var(--color-text)] transition-colors group-hover:text-[var(--color-primary)]">
+        <h2 className="mb-2 text-lg font-semibold text-[var(--color-text)] transition-colors group-hover:text-[var(--color-primary)]">
           {post.title}
-        </h3>
+        </h2>
         <p className="flex-1 text-sm leading-relaxed text-[var(--color-text-muted)]">
           {post.summary}
         </p>

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -11,23 +11,65 @@ interface FormFields {
   message: string
 }
 
+type FormErrors = Partial<Record<keyof FormFields, string>>
+
 const EMPTY: FormFields = { name: '', email: '', subject: '', message: '' }
+
+function validate(fields: FormFields): FormErrors {
+  const errors: FormErrors = {}
+  if (!fields.name.trim()) errors.name = 'Name is required.'
+  if (!fields.email.trim()) {
+    errors.email = 'Email is required.'
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fields.email)) {
+    errors.email = 'Please enter a valid email address.'
+  }
+  if (!fields.subject.trim()) errors.subject = 'Subject is required.'
+  if (!fields.message.trim()) {
+    errors.message = 'Message is required.'
+  } else if (fields.message.trim().length < 10) {
+    errors.message = 'Message must be at least 10 characters.'
+  }
+  return errors
+}
 
 export function ContactForm() {
   const [fields, setFields] = useState<FormFields>(EMPTY)
+  const [errors, setErrors] = useState<FormErrors>({})
+  const [touched, setTouched] = useState<Partial<Record<keyof FormFields, boolean>>>({})
   const [status, setStatus] = useState<FormState>('idle')
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
-    setFields((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+    const { name, value } = e.target
+    setFields((prev) => ({ ...prev, [name]: value }))
+    if (touched[name as keyof FormFields]) {
+      setErrors((prev) => ({
+        ...prev,
+        [name]: validate({ ...fields, [name]: value })[name as keyof FormFields],
+      }))
+    }
+  }
+
+  function handleBlur(e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    const { name } = e.target
+    setTouched((prev) => ({ ...prev, [name]: true }))
+    setErrors((prev) => ({ ...prev, [name]: validate(fields)[name as keyof FormFields] }))
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    const allTouched = { name: true, email: true, subject: true, message: true }
+    setTouched(allTouched)
+    const validationErrors = validate(fields)
+    setErrors(validationErrors)
+    if (Object.keys(validationErrors).length > 0) return
+
     setStatus('submitting')
-    // Submission logic will be wired in #62
+    // Submission will be wired in #62
     await new Promise((r) => setTimeout(r, 800))
     setStatus('success')
     setFields(EMPTY)
+    setTouched({})
+    setErrors({})
   }
 
   return (
@@ -38,7 +80,9 @@ export function ContactForm() {
           name="name"
           type="text"
           value={fields.name}
+          error={touched.name ? errors.name : undefined}
           onChange={handleChange}
+          onBlur={handleBlur}
           required
         />
         <Field
@@ -46,7 +90,9 @@ export function ContactForm() {
           name="email"
           type="email"
           value={fields.email}
+          error={touched.email ? errors.email : undefined}
           onChange={handleChange}
+          onBlur={handleBlur}
           required
         />
       </div>
@@ -55,9 +101,13 @@ export function ContactForm() {
         name="subject"
         type="text"
         value={fields.subject}
+        error={touched.subject ? errors.subject : undefined}
         onChange={handleChange}
+        onBlur={handleBlur}
         required
       />
+
+      {/* Message textarea */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="message" className="text-sm font-medium text-[var(--color-text)]">
           Message <span className="text-[var(--color-primary)]">*</span>
@@ -66,12 +116,22 @@ export function ContactForm() {
           id="message"
           name="message"
           rows={6}
-          required
           value={fields.message}
           onChange={handleChange}
+          onBlur={handleBlur}
           placeholder="Your message…"
-          className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20 resize-none"
+          aria-describedby={errors.message ? 'message-error' : undefined}
+          className={`resize-none rounded-lg border bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:ring-2 focus:ring-[var(--color-primary)]/20 ${
+            touched.message && errors.message
+              ? 'border-red-500 focus:border-red-500'
+              : 'border-[var(--color-border)] focus:border-[var(--color-primary)]'
+          }`}
         />
+        {touched.message && errors.message && (
+          <p id="message-error" className="text-xs text-red-500">
+            {errors.message}
+          </p>
+        )}
       </div>
 
       <button
@@ -101,11 +161,14 @@ interface FieldProps {
   name: string
   type: string
   value: string
+  error?: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onBlur: (e: React.FocusEvent<HTMLInputElement>) => void
   required?: boolean
 }
 
-function Field({ label, name, type, value, onChange, required }: FieldProps) {
+function Field({ label, name, type, value, error, onChange, onBlur, required }: FieldProps) {
+  const errorId = `${name}-error`
   return (
     <div className="flex flex-col gap-1.5">
       <label htmlFor={name} className="text-sm font-medium text-[var(--color-text)]">
@@ -115,12 +178,23 @@ function Field({ label, name, type, value, onChange, required }: FieldProps) {
         id={name}
         name={name}
         type={type}
-        required={required}
         value={value}
         onChange={onChange}
+        onBlur={onBlur}
         placeholder={label}
-        className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20"
+        aria-describedby={error ? errorId : undefined}
+        aria-invalid={!!error}
+        className={`rounded-lg border bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:ring-2 focus:ring-[var(--color-primary)]/20 ${
+          error
+            ? 'border-red-500 focus:border-red-500'
+            : 'border-[var(--color-border)] focus:border-[var(--color-primary)]'
+        }`}
       />
+      {error && (
+        <p id={errorId} className="text-xs text-red-500">
+          {error}
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { useState } from 'react'
+
+type FormState = 'idle' | 'submitting' | 'success' | 'error'
+
+interface FormFields {
+  name: string
+  email: string
+  subject: string
+  message: string
+}
+
+const EMPTY: FormFields = { name: '', email: '', subject: '', message: '' }
+
+export function ContactForm() {
+  const [fields, setFields] = useState<FormFields>(EMPTY)
+  const [status, setStatus] = useState<FormState>('idle')
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    setFields((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus('submitting')
+    // Submission logic will be wired in #62
+    await new Promise((r) => setTimeout(r, 800))
+    setStatus('success')
+    setFields(EMPTY)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
+      <div className="grid gap-5 sm:grid-cols-2">
+        <Field
+          label="Name"
+          name="name"
+          type="text"
+          value={fields.name}
+          onChange={handleChange}
+          required
+        />
+        <Field
+          label="Email"
+          name="email"
+          type="email"
+          value={fields.email}
+          onChange={handleChange}
+          required
+        />
+      </div>
+      <Field
+        label="Subject"
+        name="subject"
+        type="text"
+        value={fields.subject}
+        onChange={handleChange}
+        required
+      />
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="message" className="text-sm font-medium text-[var(--color-text)]">
+          Message <span className="text-[var(--color-primary)]">*</span>
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          rows={6}
+          required
+          value={fields.message}
+          onChange={handleChange}
+          placeholder="Your message…"
+          className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20 resize-none"
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="rounded-lg bg-[var(--color-primary)] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-primary-hover)] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {status === 'submitting' ? 'Sending…' : 'Send Message'}
+      </button>
+
+      {status === 'success' && (
+        <p className="rounded-lg bg-green-50 px-4 py-3 text-sm font-medium text-green-700 dark:bg-green-950/30 dark:text-green-400">
+          Message sent! I&apos;ll get back to you soon.
+        </p>
+      )}
+      {status === 'error' && (
+        <p className="rounded-lg bg-red-50 px-4 py-3 text-sm font-medium text-red-700 dark:bg-red-950/30 dark:text-red-400">
+          Something went wrong. Please try again or email me directly.
+        </p>
+      )}
+    </form>
+  )
+}
+
+interface FieldProps {
+  label: string
+  name: string
+  type: string
+  value: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  required?: boolean
+}
+
+function Field({ label, name, type, value, onChange, required }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={name} className="text-sm font-medium text-[var(--color-text)]">
+        {label} {required && <span className="text-[var(--color-primary)]">*</span>}
+      </label>
+      <input
+        id={name}
+        name={name}
+        type={type}
+        required={required}
+        value={value}
+        onChange={onChange}
+        placeholder={label}
+        className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-subtle)] outline-none transition-colors focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20"
+      />
+    </div>
+  )
+}

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -64,12 +64,20 @@ export function ContactForm() {
     if (Object.keys(validationErrors).length > 0) return
 
     setStatus('submitting')
-    // Submission will be wired in #62
-    await new Promise((r) => setTimeout(r, 800))
-    setStatus('success')
-    setFields(EMPTY)
-    setTouched({})
-    setErrors({})
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(fields),
+      })
+      if (!res.ok) throw new Error('Failed')
+      setStatus('success')
+      setFields(EMPTY)
+      setTouched({})
+      setErrors({})
+    } catch {
+      setStatus('error')
+    }
   }
 
   return (

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
+
+import { Toast } from '@/components/ui/Toast'
 
 type FormState = 'idle' | 'submitting' | 'success' | 'error'
 
@@ -37,6 +39,8 @@ export function ContactForm() {
   const [errors, setErrors] = useState<FormErrors>({})
   const [touched, setTouched] = useState<Partial<Record<keyof FormFields, boolean>>>({})
   const [status, setStatus] = useState<FormState>('idle')
+  const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
+  const dismissToast = useCallback(() => setToast(null), [])
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     const { name, value } = e.target
@@ -75,8 +79,13 @@ export function ContactForm() {
       setFields(EMPTY)
       setTouched({})
       setErrors({})
+      setToast({ type: 'success', message: "Message sent! I'll get back to you soon." })
     } catch {
       setStatus('error')
+      setToast({
+        type: 'error',
+        message: 'Something went wrong. Please try again or email me directly.',
+      })
     }
   }
 
@@ -150,16 +159,7 @@ export function ContactForm() {
         {status === 'submitting' ? 'Sending…' : 'Send Message'}
       </button>
 
-      {status === 'success' && (
-        <p className="rounded-lg bg-green-50 px-4 py-3 text-sm font-medium text-green-700 dark:bg-green-950/30 dark:text-green-400">
-          Message sent! I&apos;ll get back to you soon.
-        </p>
-      )}
-      {status === 'error' && (
-        <p className="rounded-lg bg-red-50 px-4 py-3 text-sm font-medium text-red-700 dark:bg-red-950/30 dark:text-red-400">
-          Something went wrong. Please try again or email me directly.
-        </p>
-      )}
+      {toast && <Toast type={toast.type} message={toast.message} onClose={dismissToast} />}
     </form>
   )
 }

--- a/src/components/home/CallToAction.tsx
+++ b/src/components/home/CallToAction.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+
+export function CallToAction() {
+  return (
+    <section className="bg-[var(--color-bg-subtle)]">
+      <div className="mx-auto max-w-6xl px-6 py-20 text-center">
+        <h2 className="mb-4 text-3xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-4xl">
+          Let&apos;s build something together
+        </h2>
+        <p className="mx-auto mb-8 max-w-xl text-lg text-[var(--color-text-muted)]">
+          Have a project in mind or just want to say hello? My inbox is always open.
+        </p>
+        <Link
+          href="/contact"
+          className="inline-block rounded-lg bg-[var(--color-primary)] px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-primary-hover)]"
+        >
+          Get in Touch
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/FeaturedProjects.tsx
+++ b/src/components/home/FeaturedProjects.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
 import { featuredProjects } from '@/data/projects'
+import { ProjectCard } from '@/components/projects/ProjectCard'
 
 export function FeaturedProjects() {
   return (
@@ -24,52 +25,8 @@ export function FeaturedProjects() {
 
       <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {featuredProjects.map((project) => (
-          <li
-            key={project.slug}
-            className="flex flex-col rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 transition-shadow hover:shadow-md"
-          >
-            <h3 className="mb-2 text-lg font-semibold text-[var(--color-text)]">{project.title}</h3>
-            <p className="mb-4 flex-1 text-sm leading-relaxed text-[var(--color-text-muted)]">
-              {project.description}
-            </p>
-            <div className="mb-4 flex flex-wrap gap-2">
-              {project.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-md bg-[var(--color-bg-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-muted)]"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-            <div className="flex gap-4">
-              {project.githubUrl && (
-                <a
-                  href={project.githubUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm font-medium text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
-                >
-                  GitHub
-                </a>
-              )}
-              {project.liveUrl && (
-                <a
-                  href={project.liveUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm font-medium text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
-                >
-                  Live Demo
-                </a>
-              )}
-              <Link
-                href={`/projects/${project.slug}`}
-                className="ml-auto text-sm font-medium text-[var(--color-primary)] transition-colors hover:text-[var(--color-primary-hover)]"
-              >
-                Details →
-              </Link>
-            </div>
+          <li key={project.slug}>
+            <ProjectCard project={project} />
           </li>
         ))}
       </ul>

--- a/src/components/home/FeaturedProjects.tsx
+++ b/src/components/home/FeaturedProjects.tsx
@@ -1,38 +1,6 @@
 import Link from 'next/link'
 
-import { type Project } from '@/types/project'
-
-const FEATURED_PROJECTS: Project[] = [
-  {
-    slug: 'project-one',
-    title: 'Project One',
-    description:
-      'A full-stack web application built with Next.js, TypeScript, and PostgreSQL. Focuses on performance and accessibility.',
-    tags: ['Next.js', 'TypeScript', 'PostgreSQL'],
-    githubUrl: 'https://github.com/espython',
-    liveUrl: '#',
-    featured: true,
-  },
-  {
-    slug: 'project-two',
-    title: 'Project Two',
-    description:
-      'An open-source CLI tool that automates repetitive development tasks and integrates with popular CI/CD pipelines.',
-    tags: ['Node.js', 'CLI', 'CI/CD'],
-    githubUrl: 'https://github.com/espython',
-    featured: true,
-  },
-  {
-    slug: 'project-three',
-    title: 'Project Three',
-    description:
-      'A real-time dashboard for monitoring system metrics, built with WebSockets and React.',
-    tags: ['React', 'WebSockets', 'Tailwind CSS'],
-    githubUrl: 'https://github.com/espython',
-    liveUrl: '#',
-    featured: true,
-  },
-]
+import { featuredProjects } from '@/data/projects'
 
 export function FeaturedProjects() {
   return (
@@ -55,7 +23,7 @@ export function FeaturedProjects() {
       </div>
 
       <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {FEATURED_PROJECTS.map((project) => (
+        {featuredProjects.map((project) => (
           <li
             key={project.slug}
             className="flex flex-col rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 transition-shadow hover:shadow-md"

--- a/src/components/home/FeaturedProjects.tsx
+++ b/src/components/home/FeaturedProjects.tsx
@@ -1,0 +1,123 @@
+import Link from 'next/link'
+
+interface Project {
+  slug: string
+  title: string
+  description: string
+  tags: string[]
+  githubUrl?: string
+  liveUrl?: string
+}
+
+const FEATURED_PROJECTS: Project[] = [
+  {
+    slug: 'project-one',
+    title: 'Project One',
+    description:
+      'A full-stack web application built with Next.js, TypeScript, and PostgreSQL. Focuses on performance and accessibility.',
+    tags: ['Next.js', 'TypeScript', 'PostgreSQL'],
+    githubUrl: 'https://github.com/espython',
+    liveUrl: '#',
+  },
+  {
+    slug: 'project-two',
+    title: 'Project Two',
+    description:
+      'An open-source CLI tool that automates repetitive development tasks and integrates with popular CI/CD pipelines.',
+    tags: ['Node.js', 'CLI', 'CI/CD'],
+    githubUrl: 'https://github.com/espython',
+  },
+  {
+    slug: 'project-three',
+    title: 'Project Three',
+    description:
+      'A real-time dashboard for monitoring system metrics, built with WebSockets and React.',
+    tags: ['React', 'WebSockets', 'Tailwind CSS'],
+    githubUrl: 'https://github.com/espython',
+    liveUrl: '#',
+  },
+]
+
+export function FeaturedProjects() {
+  return (
+    <section className="mx-auto max-w-6xl px-6 py-20">
+      <div className="mb-10 flex items-end justify-between">
+        <div>
+          <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+            My Work
+          </p>
+          <h2 className="text-3xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-4xl">
+            Featured Projects
+          </h2>
+        </div>
+        <Link
+          href="/projects"
+          className="hidden text-sm font-medium text-[var(--color-primary)] transition-colors hover:text-[var(--color-primary-hover)] sm:block"
+        >
+          View all →
+        </Link>
+      </div>
+
+      <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {FEATURED_PROJECTS.map((project) => (
+          <li
+            key={project.slug}
+            className="flex flex-col rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 transition-shadow hover:shadow-md"
+          >
+            <h3 className="mb-2 text-lg font-semibold text-[var(--color-text)]">{project.title}</h3>
+            <p className="mb-4 flex-1 text-sm leading-relaxed text-[var(--color-text-muted)]">
+              {project.description}
+            </p>
+            <div className="mb-4 flex flex-wrap gap-2">
+              {project.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-md bg-[var(--color-bg-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-muted)]"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <div className="flex gap-4">
+              {project.githubUrl && (
+                <a
+                  href={project.githubUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-medium text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
+                >
+                  GitHub
+                </a>
+              )}
+              {project.liveUrl && (
+                <a
+                  href={project.liveUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-medium text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
+                >
+                  Live Demo
+                </a>
+              )}
+              <Link
+                href={`/projects/${project.slug}`}
+                className="ml-auto text-sm font-medium text-[var(--color-primary)] transition-colors hover:text-[var(--color-primary-hover)]"
+              >
+                Details →
+              </Link>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-8 sm:hidden">
+        <Link
+          href="/projects"
+          className="text-sm font-medium text-[var(--color-primary)] transition-colors hover:text-[var(--color-primary-hover)]"
+        >
+          View all projects →
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/FeaturedProjects.tsx
+++ b/src/components/home/FeaturedProjects.tsx
@@ -1,13 +1,6 @@
 import Link from 'next/link'
 
-interface Project {
-  slug: string
-  title: string
-  description: string
-  tags: string[]
-  githubUrl?: string
-  liveUrl?: string
-}
+import { type Project } from '@/types/project'
 
 const FEATURED_PROJECTS: Project[] = [
   {
@@ -18,6 +11,7 @@ const FEATURED_PROJECTS: Project[] = [
     tags: ['Next.js', 'TypeScript', 'PostgreSQL'],
     githubUrl: 'https://github.com/espython',
     liveUrl: '#',
+    featured: true,
   },
   {
     slug: 'project-two',
@@ -26,6 +20,7 @@ const FEATURED_PROJECTS: Project[] = [
       'An open-source CLI tool that automates repetitive development tasks and integrates with popular CI/CD pipelines.',
     tags: ['Node.js', 'CLI', 'CI/CD'],
     githubUrl: 'https://github.com/espython',
+    featured: true,
   },
   {
     slug: 'project-three',
@@ -35,6 +30,7 @@ const FEATURED_PROJECTS: Project[] = [
     tags: ['React', 'WebSockets', 'Tailwind CSS'],
     githubUrl: 'https://github.com/espython',
     liveUrl: '#',
+    featured: true,
   },
 ]
 

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+
+export function Hero() {
+  return (
+    <section className="mx-auto flex max-w-6xl flex-col items-start justify-center gap-6 px-6 py-24 md:py-36">
+      <p className="text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+        Hey, I&apos;m
+      </p>
+
+      <h1 className="text-4xl font-extrabold leading-tight tracking-tight text-[var(--color-text)] sm:text-5xl md:text-6xl">
+        YourName
+        <span className="block text-[var(--color-primary)]">Full-Stack Developer</span>
+      </h1>
+
+      <p className="max-w-2xl text-lg leading-relaxed text-[var(--color-text-muted)]">
+        I build fast, accessible web applications with modern tools. Passionate about clean code,
+        great UX, and sharing what I learn.
+      </p>
+
+      <div className="flex flex-wrap gap-4 pt-2">
+        <Link
+          href="/projects"
+          className="rounded-lg bg-[var(--color-primary)] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-primary-hover)]"
+        >
+          View Projects
+        </Link>
+        <Link
+          href="/contact"
+          className="rounded-lg border border-[var(--color-border)] px-6 py-3 text-sm font-semibold text-[var(--color-text)] transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]"
+        >
+          Get in Touch
+        </Link>
+      </div>
+
+      <div className="flex items-center gap-5 pt-2">
+        <a
+          href="https://github.com/espython"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
+        >
+          GitHub
+        </a>
+        <span className="text-[var(--color-border)]">·</span>
+        <a
+          href="https://linkedin.com/in/yourname"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
+        >
+          LinkedIn
+        </a>
+        <span className="text-[var(--color-border)]">·</span>
+        <a
+          href="https://twitter.com/yourname"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
+        >
+          Twitter
+        </a>
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -8,13 +8,14 @@ export function Hero() {
       </p>
 
       <h1 className="text-4xl font-extrabold leading-tight tracking-tight text-[var(--color-text)] sm:text-5xl md:text-6xl">
-        YourName
-        <span className="block text-[var(--color-primary)]">Full-Stack Developer</span>
+        Eslam Mahmoud
+        <span className="block text-[var(--color-primary)]">Full Stack Engineer</span>
       </h1>
 
       <p className="max-w-2xl text-lg leading-relaxed text-[var(--color-text-muted)]">
-        I build fast, accessible web applications with modern tools. Passionate about clean code,
-        great UX, and sharing what I learn.
+        Senior Full Stack Engineer with 6+ years building scalable web applications. I work across
+        the stack with TypeScript, React, Node.js, and AWS — and care deeply about clean
+        architecture, performance, and developer experience.
       </p>
 
       <div className="flex flex-wrap gap-4 pt-2">
@@ -43,21 +44,12 @@ export function Hero() {
         </a>
         <span className="text-[var(--color-border)]">·</span>
         <a
-          href="https://linkedin.com/in/yourname"
+          href="https://www.linkedin.com/in/eslam-mahmoud-a63b06116/"
           target="_blank"
           rel="noopener noreferrer"
           className="text-sm text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
         >
           LinkedIn
-        </a>
-        <span className="text-[var(--color-border)]">·</span>
-        <a
-          href="https://twitter.com/yourname"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sm text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
-        >
-          Twitter
         </a>
       </div>
     </section>

--- a/src/components/home/LatestPosts.tsx
+++ b/src/components/home/LatestPosts.tsx
@@ -1,33 +1,6 @@
 import Link from 'next/link'
 
-import { type PostMeta } from '@/types/post'
-
-const LATEST_POSTS: PostMeta[] = [
-  {
-    slug: 'getting-started-with-nextjs-15',
-    title: 'Getting Started with Next.js 15',
-    date: '2026-03-20',
-    summary:
-      'A deep dive into what changed in Next.js 15 — new APIs, breaking changes, and how to migrate your existing app.',
-    tags: ['Next.js', 'React'],
-  },
-  {
-    slug: 'mastering-tailwind-css-v4',
-    title: 'Mastering Tailwind CSS v4',
-    date: '2026-03-10',
-    summary:
-      'Tailwind v4 rewrites the engine from scratch. Here is what the new CSS-first config means for your workflow.',
-    tags: ['CSS', 'Tailwind'],
-  },
-  {
-    slug: 'typescript-tips-for-react-devs',
-    title: 'TypeScript Tips for React Developers',
-    date: '2026-02-28',
-    summary:
-      'Practical patterns I use daily: discriminated unions, generic components, and avoiding the any escape hatch.',
-    tags: ['TypeScript', 'React'],
-  },
-]
+import { getAllPostsMeta } from '@/lib/posts'
 
 function formatDate(iso: string) {
   return new Date(iso).toLocaleDateString('en-US', {
@@ -38,6 +11,8 @@ function formatDate(iso: string) {
 }
 
 export function LatestPosts() {
+  const posts = getAllPostsMeta().slice(0, 3)
+
   return (
     <section className="mx-auto max-w-6xl px-6 py-20">
       <div className="mb-10 flex items-end justify-between">
@@ -58,7 +33,7 @@ export function LatestPosts() {
       </div>
 
       <ul className="divide-y divide-[var(--color-border)]">
-        {LATEST_POSTS.map((post) => (
+        {posts.map((post) => (
           <li key={post.slug} className="group py-6">
             <Link href={`/blog/${post.slug}`} className="block">
               <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-6">

--- a/src/components/home/LatestPosts.tsx
+++ b/src/components/home/LatestPosts.tsx
@@ -1,12 +1,6 @@
 import Link from 'next/link'
 
-interface PostMeta {
-  slug: string
-  title: string
-  date: string
-  summary: string
-  tags: string[]
-}
+import { type PostMeta } from '@/types/post'
 
 const LATEST_POSTS: PostMeta[] = [
   {

--- a/src/components/home/LatestPosts.tsx
+++ b/src/components/home/LatestPosts.tsx
@@ -1,0 +1,111 @@
+import Link from 'next/link'
+
+interface PostMeta {
+  slug: string
+  title: string
+  date: string
+  summary: string
+  tags: string[]
+}
+
+const LATEST_POSTS: PostMeta[] = [
+  {
+    slug: 'getting-started-with-nextjs-15',
+    title: 'Getting Started with Next.js 15',
+    date: '2026-03-20',
+    summary:
+      'A deep dive into what changed in Next.js 15 — new APIs, breaking changes, and how to migrate your existing app.',
+    tags: ['Next.js', 'React'],
+  },
+  {
+    slug: 'mastering-tailwind-css-v4',
+    title: 'Mastering Tailwind CSS v4',
+    date: '2026-03-10',
+    summary:
+      'Tailwind v4 rewrites the engine from scratch. Here is what the new CSS-first config means for your workflow.',
+    tags: ['CSS', 'Tailwind'],
+  },
+  {
+    slug: 'typescript-tips-for-react-devs',
+    title: 'TypeScript Tips for React Developers',
+    date: '2026-02-28',
+    summary:
+      'Practical patterns I use daily: discriminated unions, generic components, and avoiding the any escape hatch.',
+    tags: ['TypeScript', 'React'],
+  },
+]
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export function LatestPosts() {
+  return (
+    <section className="mx-auto max-w-6xl px-6 py-20">
+      <div className="mb-10 flex items-end justify-between">
+        <div>
+          <p className="mb-2 text-sm font-medium tracking-widest text-[var(--color-primary)] uppercase">
+            From the Blog
+          </p>
+          <h2 className="text-3xl font-extrabold tracking-tight text-[var(--color-text)] sm:text-4xl">
+            Latest Posts
+          </h2>
+        </div>
+        <Link
+          href="/blog"
+          className="hidden text-sm font-medium text-[var(--color-primary)] transition-colors hover:text-[var(--color-primary-hover)] sm:block"
+        >
+          All posts →
+        </Link>
+      </div>
+
+      <ul className="divide-y divide-[var(--color-border)]">
+        {LATEST_POSTS.map((post) => (
+          <li key={post.slug} className="group py-6">
+            <Link href={`/blog/${post.slug}`} className="block">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-6">
+                <time
+                  dateTime={post.date}
+                  className="shrink-0 text-sm text-[var(--color-text-subtle)] sm:w-36"
+                >
+                  {formatDate(post.date)}
+                </time>
+                <div className="flex-1">
+                  <h3 className="mb-1 text-lg font-semibold text-[var(--color-text)] transition-colors group-hover:text-[var(--color-primary)]">
+                    {post.title}
+                  </h3>
+                  <p className="mb-3 text-sm leading-relaxed text-[var(--color-text-muted)]">
+                    {post.summary}
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {post.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="rounded-md bg-[var(--color-bg-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-muted)]"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-6 sm:hidden">
+        <Link
+          href="/blog"
+          className="text-sm font-medium text-[var(--color-primary)] transition-colors hover:text-[var(--color-primary-hover)]"
+        >
+          All posts →
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,8 +2,7 @@ import Link from 'next/link'
 
 const SOCIAL_LINKS = [
   { href: 'https://github.com/espython', label: 'GitHub' },
-  { href: 'https://linkedin.com/in/yourname', label: 'LinkedIn' },
-  { href: 'https://twitter.com/yourname', label: 'Twitter' },
+  { href: 'https://www.linkedin.com/in/eslam-mahmoud-a63b06116/', label: 'LinkedIn' },
 ]
 
 const NAV_LINKS = [
@@ -26,10 +25,10 @@ export function Footer() {
               href="/"
               className="text-base font-bold text-[var(--color-primary)] hover:opacity-80"
             >
-              YourName.dev
+              espython.dev
             </Link>
             <p className="mt-1 text-xs text-[var(--color-text-subtle)]">
-              Building things on the web.
+              Full Stack Engineer · Luxor, Egypt
             </p>
           </div>
 
@@ -65,7 +64,7 @@ export function Footer() {
         </div>
 
         <p className="mt-8 text-xs text-[var(--color-text-subtle)]">
-          © {year} YourName.dev — Built with Next.js & Tailwind CSS
+          © {year} Eslam Mahmoud — Built with Next.js &amp; Tailwind CSS
         </p>
       </div>
     </footer>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -29,7 +29,7 @@ export function Navbar() {
           href="/"
           className="text-lg font-bold text-[var(--color-primary)] transition-opacity hover:opacity-80"
         >
-          YourName.dev
+          espython.dev
         </Link>
 
         {/* Desktop links */}

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link'
+
+import { type Project } from '@/types/project'
+
+interface ProjectCardProps {
+  project: Project
+}
+
+export function ProjectCard({ project }: ProjectCardProps) {
+  return (
+    <article className="flex flex-col rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 transition-shadow hover:shadow-md">
+      <h3 className="mb-2 text-lg font-semibold text-[var(--color-text)]">{project.title}</h3>
+      <p className="mb-4 flex-1 text-sm leading-relaxed text-[var(--color-text-muted)]">
+        {project.description}
+      </p>
+      <div className="mb-4 flex flex-wrap gap-2">
+        {project.tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-md bg-[var(--color-bg-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--color-text-muted)]"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+      <div className="flex gap-4">
+        {project.githubUrl && (
+          <a
+            href={project.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
+          >
+            GitHub
+          </a>
+        )}
+        {project.liveUrl && (
+          <a
+            href={project.liveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-primary)]"
+          >
+            Live Demo
+          </a>
+        )}
+        <Link
+          href={`/projects/${project.slug}`}
+          className="ml-auto text-sm font-medium text-[var(--color-primary)] transition-colors hover:text-[var(--color-primary-hover)]"
+        >
+          Details →
+        </Link>
+      </div>
+    </article>
+  )
+}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect } from 'react'
+
+type ToastType = 'success' | 'error'
+
+interface ToastProps {
+  type: ToastType
+  message: string
+  onClose: () => void
+  duration?: number
+}
+
+export function Toast({ type, message, onClose, duration = 4000 }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, duration)
+    return () => clearTimeout(timer)
+  }, [onClose, duration])
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className={`fixed bottom-6 right-6 z-50 flex items-start gap-3 rounded-xl px-5 py-4 shadow-lg transition-all ${
+        type === 'success'
+          ? 'bg-green-50 text-green-800 ring-1 ring-green-200 dark:bg-green-950/60 dark:text-green-300 dark:ring-green-800'
+          : 'bg-red-50 text-red-800 ring-1 ring-red-200 dark:bg-red-950/60 dark:text-red-300 dark:ring-red-800'
+      }`}
+    >
+      <span className="mt-0.5 text-lg leading-none" aria-hidden>
+        {type === 'success' ? '✓' : '✕'}
+      </span>
+      <p className="text-sm font-medium">{message}</p>
+      <button
+        onClick={onClose}
+        aria-label="Dismiss"
+        className="ml-2 text-current opacity-50 transition-opacity hover:opacity-100"
+      >
+        ✕
+      </button>
+    </div>
+  )
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -2,49 +2,49 @@ import { type Project } from '@/types/project'
 
 export const projects: Project[] = [
   {
-    slug: 'project-one',
-    title: 'Project One',
+    slug: 'strapi-firebase-auth',
+    title: 'Strapi Firebase Auth',
     description:
-      'A full-stack web application built with Next.js, TypeScript, and PostgreSQL. Focuses on performance and accessibility.',
+      'Open-source Strapi plugin that integrates Firebase Authentication — supports social providers, custom tokens, and role syncing.',
     longDescription:
-      'This project was born out of a need to manage complex data workflows in a team environment. It features role-based access control, real-time updates via Server-Sent Events, and a fully accessible UI built to WCAG 2.1 AA standards.',
-    tags: ['Next.js', 'TypeScript', 'PostgreSQL'],
-    githubUrl: 'https://github.com/espython',
-    liveUrl: '#',
-    featured: true,
-    coverImage: '/images/projects/project-one.png',
-  },
-  {
-    slug: 'project-two',
-    title: 'Project Two',
-    description:
-      'An open-source CLI tool that automates repetitive development tasks and integrates with popular CI/CD pipelines.',
-    longDescription:
-      'Built to eliminate the boilerplate overhead in day-to-day development. Supports plugins, custom templates, and hooks. Integrates with GitHub Actions, GitLab CI, and CircleCI out of the box.',
-    tags: ['Node.js', 'CLI', 'CI/CD'],
-    githubUrl: 'https://github.com/espython',
+      'Published on the official Strapi Marketplace. Enables Firebase Authentication in any Strapi v4 application. Supports multiple social providers (Google, Facebook, Apple), custom token flows, and automatic Strapi role assignment based on Firebase claims. Used by teams who need a headless CMS with a modern auth layer without rolling their own.',
+    tags: ['Node.js', 'Strapi', 'Firebase', 'Open Source'],
+    githubUrl: 'https://github.com/swensonhe/strapi-firebase-auth',
+    liveUrl: 'https://market.strapi.io/plugins/@swensonhe-strapi-plugin-firebase-auth',
     featured: true,
   },
   {
-    slug: 'project-three',
-    title: 'Project Three',
+    slug: 'mcmakler',
+    title: 'McMakler',
     description:
-      'A real-time dashboard for monitoring system metrics, built with WebSockets and React.',
+      "Germany's leading digital real estate platform — connecting buyers, sellers, and agents through a seamless online experience.",
     longDescription:
-      'Streams live CPU, memory, and network metrics from a Node.js agent to a React dashboard over WebSockets. Supports configurable alerting thresholds and historical charting.',
-    tags: ['React', 'WebSockets', 'Tailwind CSS'],
-    githubUrl: 'https://github.com/espython',
-    liveUrl: '#',
+      "McMakler is one of Germany's largest PropTech companies, offering a hybrid real estate service that combines an online platform with local agents. Contributed to the platform's web frontend, focusing on listing search, property detail pages, and agent-facing tools.",
+    tags: ['React', 'TypeScript', 'Web'],
+    liveUrl: 'https://www.mcmakler.de/',
     featured: true,
   },
   {
-    slug: 'project-four',
-    title: 'Project Four',
-    description: 'A markdown-based static site generator with a focus on developer experience.',
+    slug: 'do365',
+    title: 'do365',
+    description:
+      'Cloud-based template management for Office 365 — Word, Outlook, PowerPoint, and Excel — built with React, Node.js, C#, and .NET.',
     longDescription:
-      'A lightweight static site generator that transforms Markdown + frontmatter into a production-ready site. Supports custom themes, syntax highlighting, and incremental builds.',
-    tags: ['TypeScript', 'Markdown', 'Node.js'],
-    githubUrl: 'https://github.com/espython',
+      'do365 lets organisations manage, distribute, and enforce branded document templates across Office 365 apps. The system integrates with Microsoft Graph to push templates directly into users&apos; Office applications. Built with a React frontend, Node.js API layer, and a C#/.NET backend handling authentication and template rendering.',
+    tags: ['React', 'Node.js', 'C#', '.NET', 'Office 365'],
+    liveUrl: 'https://www.do365.nl',
+    featured: true,
+  },
+  {
+    slug: 'portfolio-blog',
+    title: 'espython.dev',
+    description:
+      'This site — a portfolio and blog built with Next.js 16, TypeScript, Tailwind CSS v4, and Netlify.',
+    longDescription:
+      'Designed and built from scratch with a focus on performance and accessibility. Features a statically generated blog backed by Markdown files, dynamic OG images, a contact form powered by Resend, and a perfect Lighthouse score across all pages.',
+    tags: ['Next.js', 'TypeScript', 'Tailwind CSS', 'Netlify'],
+    githubUrl: 'https://github.com/espython/portfolio-blog',
+    liveUrl: 'https://espython.dev',
     featured: false,
   },
 ]

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,52 @@
+import { type Project } from '@/types/project'
+
+export const projects: Project[] = [
+  {
+    slug: 'project-one',
+    title: 'Project One',
+    description:
+      'A full-stack web application built with Next.js, TypeScript, and PostgreSQL. Focuses on performance and accessibility.',
+    longDescription:
+      'This project was born out of a need to manage complex data workflows in a team environment. It features role-based access control, real-time updates via Server-Sent Events, and a fully accessible UI built to WCAG 2.1 AA standards.',
+    tags: ['Next.js', 'TypeScript', 'PostgreSQL'],
+    githubUrl: 'https://github.com/espython',
+    liveUrl: '#',
+    featured: true,
+    coverImage: '/images/projects/project-one.png',
+  },
+  {
+    slug: 'project-two',
+    title: 'Project Two',
+    description:
+      'An open-source CLI tool that automates repetitive development tasks and integrates with popular CI/CD pipelines.',
+    longDescription:
+      'Built to eliminate the boilerplate overhead in day-to-day development. Supports plugins, custom templates, and hooks. Integrates with GitHub Actions, GitLab CI, and CircleCI out of the box.',
+    tags: ['Node.js', 'CLI', 'CI/CD'],
+    githubUrl: 'https://github.com/espython',
+    featured: true,
+  },
+  {
+    slug: 'project-three',
+    title: 'Project Three',
+    description:
+      'A real-time dashboard for monitoring system metrics, built with WebSockets and React.',
+    longDescription:
+      'Streams live CPU, memory, and network metrics from a Node.js agent to a React dashboard over WebSockets. Supports configurable alerting thresholds and historical charting.',
+    tags: ['React', 'WebSockets', 'Tailwind CSS'],
+    githubUrl: 'https://github.com/espython',
+    liveUrl: '#',
+    featured: true,
+  },
+  {
+    slug: 'project-four',
+    title: 'Project Four',
+    description: 'A markdown-based static site generator with a focus on developer experience.',
+    longDescription:
+      'A lightweight static site generator that transforms Markdown + frontmatter into a production-ready site. Supports custom themes, syntax highlighting, and incremental builds.',
+    tags: ['TypeScript', 'Markdown', 'Node.js'],
+    githubUrl: 'https://github.com/espython',
+    featured: false,
+  },
+]
+
+export const featuredProjects = projects.filter((p) => p.featured)

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -2,8 +2,11 @@ import fs from 'fs'
 import path from 'path'
 
 import matter from 'gray-matter'
-import { remark } from 'remark'
-import remarkHtml from 'remark-html'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import rehypePrettyCode from 'rehype-pretty-code'
+import rehypeStringify from 'rehype-stringify'
 
 import { type Post, type PostMeta } from '@/types/post'
 
@@ -42,7 +45,19 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
   const fileContents = fs.readFileSync(fullPath, 'utf8')
   const { data, content } = matter(fileContents)
 
-  const processed = await remark().use(remarkHtml).process(content)
+  const processed = await unified()
+    .use(remarkParse)
+    .use(remarkRehype)
+    .use(rehypePrettyCode, {
+      theme: {
+        dark: 'github-dark',
+        light: 'github-light',
+      },
+      keepBackground: false,
+    })
+    .use(rehypeStringify)
+    .process(content)
+
   const contentHtml = processed.toString()
 
   return {

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,60 @@
+import fs from 'fs'
+import path from 'path'
+
+import matter from 'gray-matter'
+import { remark } from 'remark'
+import remarkHtml from 'remark-html'
+
+import { type Post, type PostMeta } from '@/types/post'
+
+const postsDirectory = path.join(process.cwd(), 'posts')
+
+function getPostFiles(): string[] {
+  if (!fs.existsSync(postsDirectory)) return []
+  return fs.readdirSync(postsDirectory).filter((f) => f.endsWith('.md'))
+}
+
+export function getAllPostsMeta(): PostMeta[] {
+  const files = getPostFiles()
+
+  const posts = files.map((filename) => {
+    const slug = filename.replace(/\.md$/, '')
+    const fullPath = path.join(postsDirectory, filename)
+    const fileContents = fs.readFileSync(fullPath, 'utf8')
+    const { data } = matter(fileContents)
+
+    return {
+      slug,
+      title: data.title as string,
+      date: data.date as string,
+      summary: data.summary as string,
+      tags: (data.tags as string[]) ?? [],
+    }
+  })
+
+  return posts.sort((a, b) => (a.date < b.date ? 1 : -1))
+}
+
+export async function getPostBySlug(slug: string): Promise<Post | null> {
+  const fullPath = path.join(postsDirectory, `${slug}.md`)
+  if (!fs.existsSync(fullPath)) return null
+
+  const fileContents = fs.readFileSync(fullPath, 'utf8')
+  const { data, content } = matter(fileContents)
+
+  const processed = await remark().use(remarkHtml).process(content)
+  const contentHtml = processed.toString()
+
+  return {
+    slug,
+    title: data.title as string,
+    date: data.date as string,
+    summary: data.summary as string,
+    tags: (data.tags as string[]) ?? [],
+    contentHtml,
+  }
+}
+
+export function getAllPostSlugs(): string[] {
+  return getPostFiles().map((f) => f.replace(/\.md$/, ''))
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -73,3 +73,18 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
 export function getAllPostSlugs(): string[] {
   return getPostFiles().map((f) => f.replace(/\.md$/, ''))
 }
+
+export function getAdjacentPosts(slug: string): {
+  prev: Pick<PostMeta, 'slug' | 'title'> | null
+  next: Pick<PostMeta, 'slug' | 'title'> | null
+} {
+  const posts = getAllPostsMeta()
+  const index = posts.findIndex((p) => p.slug === slug)
+  return {
+    prev:
+      index < posts.length - 1
+        ? { slug: posts[index + 1].slug, title: posts[index + 1].title }
+        : null,
+    next: index > 0 ? { slug: posts[index - 1].slug, title: posts[index - 1].title } : null,
+  }
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -11,6 +11,12 @@ import rehypeStringify from 'rehype-stringify'
 import { type Post, type PostMeta } from '@/types/post'
 
 const postsDirectory = path.join(process.cwd(), 'posts')
+const WORDS_PER_MINUTE = 200
+
+function calcReadingTime(text: string): number {
+  const words = text.trim().split(/\s+/).length
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE))
+}
 
 function getPostFiles(): string[] {
   if (!fs.existsSync(postsDirectory)) return []
@@ -24,7 +30,7 @@ export function getAllPostsMeta(): PostMeta[] {
     const slug = filename.replace(/\.md$/, '')
     const fullPath = path.join(postsDirectory, filename)
     const fileContents = fs.readFileSync(fullPath, 'utf8')
-    const { data } = matter(fileContents)
+    const { data, content } = matter(fileContents)
 
     return {
       slug,
@@ -32,6 +38,7 @@ export function getAllPostsMeta(): PostMeta[] {
       date: data.date as string,
       summary: data.summary as string,
       tags: (data.tags as string[]) ?? [],
+      readingTime: calcReadingTime(content),
     }
   })
 
@@ -66,6 +73,7 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
     date: data.date as string,
     summary: data.summary as string,
     tags: (data.tags as string[]) ?? [],
+    readingTime: calcReadingTime(content),
     contentHtml,
   }
 }

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,11 @@
+export interface PostMeta {
+  slug: string
+  title: string
+  date: string
+  summary: string
+  tags: string[]
+}
+
+export interface Post extends PostMeta {
+  contentHtml: string
+}

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -4,6 +4,7 @@ export interface PostMeta {
   date: string
   summary: string
   tags: string[]
+  readingTime: number
 }
 
 export interface Post extends PostMeta {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,11 @@
+export interface Project {
+  slug: string
+  title: string
+  description: string
+  longDescription?: string
+  tags: string[]
+  githubUrl?: string
+  liveUrl?: string
+  featured: boolean
+  coverImage?: string
+}


### PR DESCRIPTION
## Full site release

All 10 milestones complete. This merges 36 commits from develop into main.

### What's shipping

**Layout & Core**
- Navbar (responsive + mobile menu), Footer, dark-mode toggle, design tokens
- Viewport export, brand name, real social links

**Homepage** — Hero, Featured Projects, Latest Posts, CTA

**Projects** — `/projects` listing + `/projects/[slug]` detail (strapi-firebase-auth, McMakler, do365, espython.dev)

**Blog** — `/blog` listing + `/blog/[slug]` with Markdown pipeline, syntax highlighting, reading time, prev/next navigation

**About** — Bio (Eslam Mahmoud, VOIS, Luxor), Skills grid (6 categories incl. Java/Spring/Quarkus), Experience timeline (6 roles)

**Contact** — Form with validation, Resend email integration, Toast notifications

**SEO** — `generateMetadata` on all pages, OG images (homepage + per-post), `sitemap.xml`, `robots.txt`

**Quality** — Lighthouse 97/95–96/100/100, dark-mode contrast fixes, heading order fix, README

**Content** — Real name, bio, LinkedIn, GitHub, resume PDF, 3 real projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)