### PR TITLE
fix: blog post prose colors in light mode

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -79,7 +79,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       </header>
 
       <article
-        className="prose prose-neutral max-w-none dark:prose-invert"
+        className="prose max-w-none"
         dangerouslySetInnerHTML={{ __html: post.contentHtml }}
       />
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,6 +43,25 @@
   --color-text-subtle: var(--color-text-subtle);
 }
 
+/* ── Prose (blog post body) ─────────────────────────────────── */
+.prose {
+  --tw-prose-body: var(--color-text);
+  --tw-prose-headings: var(--color-text);
+  --tw-prose-lead: var(--color-text-muted);
+  --tw-prose-links: var(--color-primary);
+  --tw-prose-bold: var(--color-text);
+  --tw-prose-counters: var(--color-text-muted);
+  --tw-prose-bullets: var(--color-text-muted);
+  --tw-prose-hr: var(--color-border);
+  --tw-prose-quotes: var(--color-text);
+  --tw-prose-quote-borders: var(--color-primary);
+  --tw-prose-captions: var(--color-text-subtle);
+  --tw-prose-code: var(--color-text);
+  --tw-prose-pre-bg: var(--color-bg-subtle);
+  --tw-prose-th-borders: var(--color-border);
+  --tw-prose-td-borders: var(--color-border);
+}
+
 /* ── Syntax highlighting (rehype-pretty-code) ───────────────── */
 [data-rehype-pretty-code-figure] pre {
   padding: 1.25rem 1.5rem;


### PR DESCRIPTION
## Problem
Blog post body text was pale/unreadable in light mode. `prose-neutral` was overriding text colors with Tailwind's neutral palette, which conflicted with our near-white `#fafaff` background.

## Fix
- Added `.prose { --tw-prose-* }` overrides in `globals.css` that tie all prose colors to our design tokens (`--color-text`, `--color-text-muted`, `--color-primary`, etc.)
- Removed `prose-neutral` and `dark:prose-invert` from the article element — our CSS variables already handle both modes correctly

## Result
- Light mode: prose body uses `--color-text` (`#111117`) — full contrast
- Dark mode: prose body uses `--color-text` (`#f0f0f8`) — same token, correct value

🤖 Generated with [Claude Code](https://claude.com/claude-code)