### PR TITLE
fix: syntax highlighting and code block colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,7 +57,7 @@
   --tw-prose-quote-borders: var(--color-primary);
   --tw-prose-captions: var(--color-text-subtle);
   --tw-prose-code: var(--color-text);
-  --tw-prose-pre-bg: var(--color-bg-subtle);
+  --tw-prose-pre-bg: #f6f8fa;
   --tw-prose-th-borders: var(--color-border);
   --tw-prose-td-borders: var(--color-border);
 }
@@ -70,12 +70,28 @@
   font-size: 0.875rem;
   line-height: 1.7;
   border: 1px solid var(--color-border);
+  background-color: #f6f8fa;
+}
+
+.dark [data-rehype-pretty-code-figure] pre {
+  background-color: #0d1117;
 }
 
 [data-rehype-pretty-code-figure] code {
   background: none;
   padding: 0;
   font-size: inherit;
+}
+
+/* Apply shiki dual-theme token colors based on light/dark class */
+code[data-theme*=' '],
+code[data-theme*=' '] span {
+  color: var(--shiki-light);
+}
+
+.dark code[data-theme*=' '],
+.dark code[data-theme*=' '] span {
+  color: var(--shiki-dark);
 }
 
 /* ── Base ───────────────────────────────────────────────────── */


### PR DESCRIPTION
## Problem
Code blocks had two issues:
1. **Light mode** — pale/washed-out background (was using `--color-bg-subtle`)
2. **Both modes** — no syntax highlighting at all

## Root cause
`rehype-pretty-code` with dual themes generates `--shiki-light` and `--shiki-dark` CSS custom properties on each token span, but **no CSS rule was applying them**. Without the activation rules, all tokens inherit the parent text color — unstyled.

## Fix
- Added `code[data-theme*=' '] span { color: var(--shiki-light) }` and `.dark` equivalent to switch token colors via the class-based theme toggle
- Set `pre` background to `#f6f8fa` (github-light) in light mode and `#0d1117` (github-dark) in dark mode, matching the shiki themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)